### PR TITLE
feat: delete and clipboard actions

### DIFF
--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -20,7 +20,6 @@ const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
   ShortcutRegistry.registry,
 );
 
-
 /**
  * Weight for the first of these three items in the context menu.
  * Changing base weight will change where this group goes in the context
@@ -81,7 +80,6 @@ export class Clipboard {
     ShortcutRegistry.registry.unregister(Constants.SHORTCUT_NAMES.COPY);
     ShortcutRegistry.registry.unregister(Constants.SHORTCUT_NAMES.PASTE);
   }
-
 
   /**
    * Create and register the keyboard shortcut for the cut action.
@@ -334,7 +332,7 @@ export class Clipboard {
    */
   private pastePrecondition(workspace: WorkspaceSvg) {
     if (!this.copyData || !this.copyWorkspace) return false;
-  
+
     return this.canCurrentlyEdit(workspace) && !Gesture.inProgress();
   }
 

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -20,6 +20,11 @@ const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
   ShortcutRegistry.registry,
 );
 
+/**
+ * Logic and state for cut/copy/paste actions as both keyboard shortcuts
+ * and context menu items.
+ * In the long term, this will likely merge with the clipboard code in core.
+ */
 export class Clipboard {
   /** Data copied by the copy or cut keyboard shortcuts. */
   private copyData: ICopyData | null = null;
@@ -122,7 +127,7 @@ export class Clipboard {
 
     ContextMenuRegistry.registry.register(copyAction);
   }
-  
+
   /**
    * Precondition function for copying a block from keyboard
    * navigation. This precondition is shared between keyboard shortcuts
@@ -179,7 +184,6 @@ export class Clipboard {
     this.copyWorkspace = sourceBlock.workspace;
     return !!this.copyData;
   }
-
 
   /**
    * Create and register the keyboard shortcut for the paste action.

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -9,7 +9,7 @@ import {
   Gesture,
   ShortcutRegistry,
   utils as BlocklyUtils,
-  ICopyData
+  ICopyData,
 } from 'blockly';
 import * as Constants from '../constants';
 import type {BlockSvg, Workspace, WorkspaceSvg} from 'blockly';
@@ -118,7 +118,6 @@ export class Clipboard {
 
     ShortcutRegistry.registry.register(cutShortcut);
   }
-
 
   private registerPasteContextMenuAction() {
     // TODO: Implement.

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -1,0 +1,297 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ContextMenuRegistry,
+  Gesture,
+  ShortcutRegistry,
+  utils as BlocklyUtils,
+  ICopyData
+} from 'blockly';
+import * as Constants from '../constants';
+import type {BlockSvg, Workspace, WorkspaceSvg} from 'blockly';
+import {Navigation} from '../navigation';
+
+const KeyCodes = BlocklyUtils.KeyCodes;
+const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
+  ShortcutRegistry.registry,
+);
+
+export class Clipboard {
+  /** Data copied by the copy or cut keyboard shortcuts. */
+  private copyData: ICopyData | null = null;
+
+  /** The workspace a copy or cut keyboard shortcut happened in. */
+  private copyWorkspace: WorkspaceSvg | null = null;
+
+  /**
+   * Function provided by the navigation controller to say whether editing
+   * is allowed.
+   */
+  private canCurrentlyEditFn: (ws: WorkspaceSvg) => boolean;
+
+  constructor(
+    private navigation: Navigation,
+    canEditFn: (ws: WorkspaceSvg) => boolean,
+  ) {
+    this.canCurrentlyEditFn = canEditFn;
+  }
+
+  /**
+   * Install these actions as both keyboard shortcuts and context menu items.
+   */
+  install() {
+    this.registerCopyShortcut();
+    this.registerCopyContextMenuAction();
+
+    this.registerPasteShortcut();
+    this.registerPasteContextMenuAction();
+
+    this.registerCutShortcut();
+    this.registerCutContextMenuAction();
+  }
+
+  /**
+   * Uninstall this action as both a keyboard shortcut and a context menu item.
+   * Reinstall the original context menu action if possible.
+   */
+  uninstall() {
+    ContextMenuRegistry.registry.unregister('blockDeleteFromContextMenu');
+
+    ShortcutRegistry.registry.unregister(Constants.SHORTCUT_NAMES.COPY);
+    ShortcutRegistry.registry.unregister(Constants.SHORTCUT_NAMES.CUT);
+    ShortcutRegistry.registry.unregister(Constants.SHORTCUT_NAMES.PASTE);
+  }
+
+  /**
+   * Create and register the keyboard shortcut for the copy action.
+   */
+  private registerCopyShortcut() {
+    const copyShortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: Constants.SHORTCUT_NAMES.COPY,
+      preconditionFn: this.copyPreconditionFn.bind(this),
+      callback: this.copyCallbackFn.bind(this),
+      keyCodes: [
+        createSerializedKey(KeyCodes.C, [KeyCodes.CTRL]),
+        createSerializedKey(KeyCodes.C, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.C, [KeyCodes.META]),
+      ],
+      allowCollision: true,
+    };
+    ShortcutRegistry.registry.register(copyShortcut);
+  }
+
+  /**
+   * Paste the copied block, to the marked location if possible or
+   * onto the workspace otherwise.
+   */
+  private registerPasteShortcut() {
+    const pasteShortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: Constants.SHORTCUT_NAMES.PASTE,
+      preconditionFn: this.pastePreconditionFn.bind(this),
+      callback: this.pasteCallbackFn.bind(this),
+      keyCodes: [
+        createSerializedKey(KeyCodes.V, [KeyCodes.CTRL]),
+        createSerializedKey(KeyCodes.V, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.V, [KeyCodes.META]),
+      ],
+      allowCollision: true,
+    };
+    ShortcutRegistry.registry.register(pasteShortcut);
+  }
+
+  private registerCutShortcut() {
+    const cutShortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: Constants.SHORTCUT_NAMES.CUT,
+      preconditionFn: this.cutPreconditionFn.bind(this),
+      callback: this.cutCallbackFn.bind(this),
+      keyCodes: [
+        createSerializedKey(KeyCodes.X, [KeyCodes.CTRL]),
+        createSerializedKey(KeyCodes.X, [KeyCodes.ALT]),
+        createSerializedKey(KeyCodes.X, [KeyCodes.META]),
+      ],
+      allowCollision: true,
+    };
+
+    ShortcutRegistry.registry.register(cutShortcut);
+  }
+
+
+  private registerPasteContextMenuAction() {
+    // TODO: Implement.
+  }
+
+  private registerCutContextMenuAction() {
+    // TODO: Implement.
+  }
+
+  /**
+   * Register the delete block action as a context menu item on blocks.
+   * This function mixes together the keyboard and context menu preconditions
+   * but only calls the keyboard callback.
+   */
+  private registerCopyContextMenuAction() {
+    const copyAction: ContextMenuRegistry.RegistryItem = {
+      displayText: (scope) => 'Clipboard: copy',
+      preconditionFn: (scope) => {
+        const ws = scope.block?.workspace;
+        if (!ws) return 'hidden';
+
+        return this.copyPreconditionFn(ws) ? 'enabled' : 'disabled';
+      },
+      callback: (scope) => {
+        const ws = scope.block?.workspace;
+        if (!ws) return;
+        return this.copyCallbackFn(ws);
+      },
+      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
+      id: 'blockCopyFromContextMenu',
+      weight: 11,
+    };
+
+    ContextMenuRegistry.registry.register(copyAction);
+  }
+
+  /**
+   * Precondition function for deleting a block from keyboard
+   * navigation. This precondition is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @returns True iff `deleteCallbackFn` function should be called.
+   */
+  private copyPreconditionFn(workspace: WorkspaceSvg) {
+    if (!this.canCurrentlyEditFn(workspace)) return false;
+    switch (this.navigation.getState(workspace)) {
+      case Constants.STATE.WORKSPACE:
+        const curNode = workspace?.getCursor()?.getCurNode();
+        const source = curNode?.getSourceBlock();
+        return !!(
+          source?.isDeletable() &&
+          source?.isMovable() &&
+          !Gesture.inProgress()
+        );
+      case Constants.STATE.FLYOUT:
+        const flyoutWorkspace = workspace.getFlyout()?.getWorkspace();
+        const sourceBlock = flyoutWorkspace
+          ?.getCursor()
+          ?.getCurNode()
+          ?.getSourceBlock();
+        return !!(sourceBlock && !Gesture.inProgress());
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Callback function for copying a block from keyboard
+   * navigation. This callback is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * FIXME: This should be better encapsulated.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @returns True if this function successfully handled copying.
+   */
+  private copyCallbackFn(workspace: WorkspaceSvg) {
+    const navigationState = this.navigation.getState(workspace);
+    let activeWorkspace: WorkspaceSvg | undefined = workspace;
+    if (navigationState === Constants.STATE.FLYOUT) {
+      activeWorkspace = workspace.getFlyout()?.getWorkspace();
+    }
+    const sourceBlock = activeWorkspace
+      ?.getCursor()
+      ?.getCurNode()
+      .getSourceBlock() as BlockSvg;
+    workspace.hideChaff();
+    this.copyData = sourceBlock.toCopyData();
+    this.copyWorkspace = sourceBlock.workspace;
+    return !!this.copyData;
+  }
+
+  /**
+   * Callback function for pasting a block from keyboard
+   * navigation. This callback is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * FIXME: This should be better encapsulated.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @returns True if this function successfully handled pasting.
+   */
+  private pasteCallbackFn(workspace: WorkspaceSvg) {
+    if (!this.copyData || !this.copyWorkspace) return false;
+    const pasteWorkspace = this.copyWorkspace.isFlyout
+      ? workspace
+      : this.copyWorkspace;
+    return this.navigation.paste(this.copyData, pasteWorkspace);
+  }
+
+  /**
+   * Precondition function for pasting a block from keyboard
+   * navigation. This precondition is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @returns True iff `blockPasteCallbackFn` function should be called.
+   */
+  private pastePreconditionFn(workspace: WorkspaceSvg) {
+    return this.canCurrentlyEditFn(workspace) && !Gesture.inProgress();
+  }
+
+  /**
+   * Callback function for cutting a block from keyboard
+   * navigation. This callback is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * FIXME: This should be better encapsulated.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @returns True if this function successfully handled cutting.
+   */
+  private cutCallbackFn(workspace: WorkspaceSvg) {
+    const sourceBlock = workspace
+      .getCursor()
+      ?.getCurNode()
+      .getSourceBlock() as BlockSvg;
+    this.copyData = sourceBlock.toCopyData();
+    this.copyWorkspace = sourceBlock.workspace;
+    this.navigation.moveCursorOnBlockDelete(workspace, sourceBlock);
+    sourceBlock.checkAndDelete();
+    return true;
+  }
+
+  /**
+   * Precondition function for cutting a block from keyboard
+   * navigation. This precondition is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @returns True iff `blockCutCallbackFn` function should be called.
+   */
+  private cutPreconditionFn(workspace: WorkspaceSvg) {
+    if (this.canCurrentlyEditFn(workspace)) {
+      const curNode = workspace.getCursor()?.getCurNode();
+      if (curNode && curNode.getSourceBlock()) {
+        const sourceBlock = curNode.getSourceBlock();
+        return !!(
+          !Gesture.inProgress() &&
+          sourceBlock &&
+          sourceBlock.isDeletable() &&
+          sourceBlock.isMovable() &&
+          !sourceBlock.workspace.isFlyout
+        );
+      }
+    }
+    return false;
+  }
+}

--- a/src/actions/clipboard.ts
+++ b/src/actions/clipboard.ts
@@ -242,6 +242,8 @@ export class Clipboard {
    * @returns True iff `pasteCallbackFn` function should be called.
    */
   private pastePreconditionFn(workspace: WorkspaceSvg) {
+    if (!this.copyData || !this.copyWorkspace) return false;
+  
     return this.canCurrentlyEditFn(workspace) && !Gesture.inProgress();
   }
 

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -96,7 +96,7 @@ export class DeleteAction {
     const deleteItem: ContextMenuRegistry.RegistryItem = {
       displayText: (scope) => {
         if (!this.oldContextMenuItem) {
-          return 'delete';
+          return 'Delete block (Del)';
         }
 
         type DisplayTextFn = (p1: ContextMenuRegistry.Scope) => string;
@@ -104,7 +104,7 @@ export class DeleteAction {
         // of blocks that will be deleted.
         const oldDisplayTextFn = this.oldContextMenuItem
           .displayText as DisplayTextFn;
-        return oldDisplayTextFn(scope);
+        return oldDisplayTextFn(scope) + ' (Del)';
       },
       preconditionFn: (scope) => {
         const ws = scope.block?.workspace;

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -31,7 +31,7 @@ export class DeleteAction {
    * Function provided by the navigation controller to say whether editing
    * is allowed.
    */
-  private canCurrentlyEditFn: (ws: WorkspaceSvg) => boolean;
+  private canCurrentlyEdit: (ws: WorkspaceSvg) => boolean;
 
   /**
    * Registration name for the keyboard shortcut.
@@ -40,9 +40,9 @@ export class DeleteAction {
 
   constructor(
     private navigation: Navigation,
-    canEditFn: (ws: WorkspaceSvg) => boolean,
+    canEdit: (ws: WorkspaceSvg) => boolean,
   ) {
-    this.canCurrentlyEditFn = canEditFn;
+    this.canCurrentlyEdit = canEdit;
   }
 
   /**
@@ -71,8 +71,8 @@ export class DeleteAction {
   private registerShortcut() {
     const deleteShortcut: ShortcutRegistry.KeyboardShortcut = {
       name: this.deleteShortcutName,
-      preconditionFn: this.deletePreconditionFn.bind(this),
-      callback: this.deleteCallbackFn.bind(this),
+      preconditionFn: this.deletePrecondition.bind(this),
+      callback: this.deleteCallback.bind(this),
       keyCodes: [KeyCodes.DELETE, KeyCodes.BACKSPACE],
       allowCollision: true,
     };
@@ -102,9 +102,9 @@ export class DeleteAction {
         type DisplayTextFn = (p1: ContextMenuRegistry.Scope) => string;
         // Use the original item's text, which is dynamic based on the number
         // of blocks that will be deleted.
-        const oldDisplayTextFn = this.oldContextMenuItem
+        const oldDisplayText = this.oldContextMenuItem
           .displayText as DisplayTextFn;
-        return oldDisplayTextFn(scope) + ' (Del)';
+        return oldDisplayText(scope) + ' (Del)';
       },
       preconditionFn: (scope) => {
         const ws = scope.block?.workspace;
@@ -120,14 +120,14 @@ export class DeleteAction {
         // Return enabled if the keyboard shortcut precondition is allowed,
         // and disabled if the context menu precondition is met but the keyboard
         // shortcut precondition is not met.
-        return this.deletePreconditionFn(ws) ? 'enabled' : 'disabled';
+        return this.deletePrecondition(ws) ? 'enabled' : 'disabled';
       },
       callback: (scope) => {
         const ws = scope.block?.workspace;
         if (!ws) return;
 
         // Delete the block(s), and put the cursor back in a sane location.
-        return this.deleteCallbackFn(ws, null);
+        return this.deleteCallback(ws, null);
       },
       scopeType: ContextMenuRegistry.ScopeType.BLOCK,
       id: 'blockDeleteFromContextMenu',
@@ -144,10 +144,10 @@ export class DeleteAction {
    *
    * @param workspace The `WorkspaceSvg` where the shortcut was
    *     invoked.
-   * @returns True iff `deleteCallbackFn` function should be called.
+   * @returns True iff `deleteCallback` function should be called.
    */
-  private deletePreconditionFn(workspace: WorkspaceSvg) {
-    if (!this.canCurrentlyEditFn(workspace)) return false;
+  private deletePrecondition(workspace: WorkspaceSvg) {
+    if (!this.canCurrentlyEdit(workspace)) return false;
 
     const sourceBlock = workspace.getCursor()?.getCurNode().getSourceBlock();
     return !!sourceBlock?.isDeletable();
@@ -164,7 +164,7 @@ export class DeleteAction {
    *     if called from a context menu.
    * @returns True if this function successfully handled deletion.
    */
-  private deleteCallbackFn(workspace: WorkspaceSvg, e: Event | null) {
+  private deleteCallback(workspace: WorkspaceSvg, e: Event | null) {
     const cursor = workspace.getCursor();
     if (!cursor) return false;
 

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  ContextMenuRegistry,
+  Gesture,
+  ShortcutRegistry,
+  utils as BlocklyUtils,
+} from 'blockly';
+import * as Constants from '../constants';
+import type {BlockSvg, WorkspaceSvg} from 'blockly';
+import {Navigation} from '../navigation';
+
+const KeyCodes = BlocklyUtils.KeyCodes;
+
+/**
+ * Action to delete the block the cursor is currently on.
+ * Registers itself as both a keyboard shortcut and a context menu item.
+ */
+export class DeleteAction {
+  /**
+   * Saved context menu item, which is re-registered when this action
+   * is uninstalled.
+   */
+  private oldContextMenuItem: ContextMenuRegistry.RegistryItem | null = null;
+
+  /**
+   * Function provided by the navigation controller to say whether editing
+   * is allowed.
+   */
+  private canCurrentlyEditFn: (ws: WorkspaceSvg) => boolean;
+
+  /**
+   * Registration name for the keyboard shortcut.
+   */
+  private deleteShortcutName = Constants.SHORTCUT_NAMES.DELETE;
+
+  constructor(
+    private navigation: Navigation,
+    canEditFn: (ws: WorkspaceSvg) => boolean,
+  ) {
+    this.canCurrentlyEditFn = canEditFn;
+  }
+
+  /**
+   * Install this action as both a keyboard shortcut and a context menu item.
+   */
+  install() {
+    this.registerShortcut();
+    this.registerContextMenuAction();
+  }
+
+  /**
+   * Uninstall this action as both a keyboard shortcut and a context menu item.
+   * Reinstall the original context menu action if possible.
+   */
+  uninstall() {
+    ContextMenuRegistry.registry.unregister('blockDeleteFromContextMenu');
+    if (this.oldContextMenuItem) {
+      ContextMenuRegistry.registry.register(this.oldContextMenuItem);
+    }
+    ShortcutRegistry.registry.unregister(this.deleteShortcutName);
+  }
+
+  /**
+   * Create and register the keyboard shortcut for this action.
+   */
+  private registerShortcut() {
+    const deleteShortcut: ShortcutRegistry.KeyboardShortcut = {
+      name: this.deleteShortcutName,
+      preconditionFn: this.deletePreconditionFn.bind(this),
+      callback: this.deleteCallbackFn.bind(this),
+      keyCodes: [KeyCodes.DELETE, KeyCodes.BACKSPACE],
+      allowCollision: true,
+    };
+    ShortcutRegistry.registry.register(deleteShortcut);
+  }
+
+  /**
+   * Register the delete block action as a context menu item on blocks.
+   * This function mixes together the keyboard and context menu preconditions
+   * but only calls the keyboard callback.
+   */
+  private registerContextMenuAction() {
+    this.oldContextMenuItem =
+      ContextMenuRegistry.registry.getItem('blockDelete');
+    
+    if (!this.oldContextMenuItem) return;
+
+    // Unregister the original item..
+    ContextMenuRegistry.registry.unregister(this.oldContextMenuItem.id);
+
+    const deleteItem: ContextMenuRegistry.RegistryItem = {
+      displayText: (scope) => {
+        if (!this.oldContextMenuItem) {
+          return 'delete';
+        }
+
+        type DisplayTextFn = (p1: ContextMenuRegistry.Scope) => string;
+        // Use the original item's text, which is dynamic based on the number
+        // of blocks that will be deleted.
+        const oldDisplayTextFn = this.oldContextMenuItem
+          .displayText as DisplayTextFn;
+        return oldDisplayTextFn(scope);
+      },
+      preconditionFn: (scope) => {
+        const ws = scope.block?.workspace;
+
+        // Run the original precondition code, from the context menu option.
+        // If the item would be hidden or disabled, respect it.
+        const originalPreconditionResult =
+          this.oldContextMenuItem!.preconditionFn(scope);
+        if (!ws || originalPreconditionResult != 'enabled') {
+          return originalPreconditionResult;
+        }
+
+        // Return enabled if the keyboard shortcut precondition is allowed,
+        // and disabled if the context menu precondition is met but the keyboard
+        // shortcut precondition is not met.
+        return this.deletePreconditionFn(ws) ? 'enabled' : 'disabled';
+      },
+      callback: (scope) => {
+        const ws = scope.block?.workspace;
+        if (!ws) return;
+
+        // Delete the block(s), and put the cursor back in a sane location.
+        return this.deleteCallbackFn(ws, null);
+      },
+      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
+      id: 'blockDeleteFromContextMenu',
+      weight: 10,
+    };
+
+    ContextMenuRegistry.registry.register(deleteItem);
+  }
+
+  /**
+   * Precondition function for deleting a block from keyboard
+   * navigation. This precondition is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @returns True iff `deleteCallbackFn` function should be called.
+   */
+  private deletePreconditionFn(workspace: WorkspaceSvg) {
+    if (!this.canCurrentlyEditFn(workspace)) return false;
+
+    const sourceBlock = workspace.getCursor()?.getCurNode().getSourceBlock();
+    return !!sourceBlock?.isDeletable();
+  }
+
+  /**
+   * Callback function for deleting a block from keyboard
+   * navigation. This callback is shared between keyboard shortcuts
+   * and context menu items.
+   *
+   * @param workspace The `WorkspaceSvg` where the shortcut was
+   *     invoked.
+   * @param e The originating event for a keyboard shortcut, or null
+   *     if called from a context menu.
+   * @returns True if this function successfully handled deletion.
+   */
+  private deleteCallbackFn(workspace: WorkspaceSvg, e: Event | null) {
+    const cursor = workspace.getCursor();
+    if (!cursor) return false;
+
+    const sourceBlock = cursor.getCurNode().getSourceBlock() as BlockSvg;
+    // Delete or backspace.
+    // There is an event if this is triggered from a keyboard shortcut,
+    // but not if it's triggered from a context menu.
+    if (e) {
+      // Stop the browser from going back to the previous page.
+      // Do this first to prevent an error in the delete code from resulting
+      // in data loss.
+      e.preventDefault();
+    }
+    // Don't delete while dragging.  Jeez.
+    if (Gesture.inProgress()) false;
+
+    this.navigation.moveCursorOnBlockDelete(workspace, sourceBlock);
+    sourceBlock.checkAndDelete();
+    return true;
+  }
+}

--- a/src/actions/delete.ts
+++ b/src/actions/delete.ts
@@ -87,7 +87,7 @@ export class DeleteAction {
   private registerContextMenuAction() {
     this.oldContextMenuItem =
       ContextMenuRegistry.registry.getItem('blockDelete');
-    
+
     if (!this.oldContextMenuItem) return;
 
     // Unregister the original item..

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -544,7 +544,7 @@ export class Navigation {
    *  - Resume editing by returning the cursor to its previous location, if any.
    *  - Move the cursor to the top connection point on on the first top block.
    *  - Move the cursor to the default location on the workspace.
-   * 
+   *
    * @param workspace The main Blockly workspace.
    * @param keepPosition Whether to retain the cursor's previous position.
    */

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -32,6 +32,7 @@ import {Announcer} from './announcer';
 import {LineCursor} from './line_cursor';
 import {ShortcutDialog} from './shortcut_dialog';
 import {DeleteAction} from './actions/delete';
+import {Clipboard} from './actions/clipboard';
 
 const KeyCodes = BlocklyUtils.KeyCodes;
 const createSerializedKey = ShortcutRegistry.registry.createSerializedKey.bind(
@@ -60,6 +61,11 @@ export class NavigationController {
 
   /** Context menu and keyboard action for delete. */
   deleteAction: DeleteAction = new DeleteAction(
+    this.navigation,
+    this.canCurrentlyEdit.bind(this),
+  );
+
+  clipboard: Clipboard = new Clipboard(
     this.navigation,
     this.canCurrentlyEdit.bind(this),
   );
@@ -638,78 +644,78 @@ export class NavigationController {
     },
 
     /** Copy the block the cursor is currently on. */
-    copy: {
-      name: Constants.SHORTCUT_NAMES.COPY,
-      preconditionFn: this.blockCopyPreconditionFn.bind(this),
-      callback: this.blockCopyCallbackFn.bind(this),
-      keyCodes: [
-        createSerializedKey(KeyCodes.C, [KeyCodes.CTRL]),
-        createSerializedKey(KeyCodes.C, [KeyCodes.ALT]),
-        createSerializedKey(KeyCodes.C, [KeyCodes.META]),
-      ],
-      allowCollision: true,
-    },
+    // copy: {
+    //   name: Constants.SHORTCUT_NAMES.COPY,
+    //   preconditionFn: this.blockCopyPreconditionFn.bind(this),
+    //   callback: this.blockCopyCallbackFn.bind(this),
+    //   keyCodes: [
+    //     createSerializedKey(KeyCodes.C, [KeyCodes.CTRL]),
+    //     createSerializedKey(KeyCodes.C, [KeyCodes.ALT]),
+    //     createSerializedKey(KeyCodes.C, [KeyCodes.META]),
+    //   ],
+    //   allowCollision: true,
+    // },
 
     /**
      * Paste the copied block, to the marked location if possible or
      * onto the workspace otherwise.
      */
-    paste: {
-      name: Constants.SHORTCUT_NAMES.PASTE,
-      preconditionFn: (workspace) =>
-        this.canCurrentlyEdit(workspace) && !Blockly.Gesture.inProgress(),
-      callback: (workspace) => {
-        if (!this.copyData || !this.copyWorkspace) return false;
-        const pasteWorkspace = this.copyWorkspace.isFlyout
-          ? workspace
-          : this.copyWorkspace;
-        return this.navigation.paste(this.copyData, pasteWorkspace);
-      },
-      keyCodes: [
-        createSerializedKey(KeyCodes.V, [KeyCodes.CTRL]),
-        createSerializedKey(KeyCodes.V, [KeyCodes.ALT]),
-        createSerializedKey(KeyCodes.V, [KeyCodes.META]),
-      ],
-      allowCollision: true,
-    },
+    // paste: {
+    //   name: Constants.SHORTCUT_NAMES.PASTE,
+    //   preconditionFn: (workspace) =>
+    //     this.canCurrentlyEdit(workspace) && !Blockly.Gesture.inProgress(),
+    //   callback: (workspace) => {
+    //     if (!this.copyData || !this.copyWorkspace) return false;
+    //     const pasteWorkspace = this.copyWorkspace.isFlyout
+    //       ? workspace
+    //       : this.copyWorkspace;
+    //     return this.navigation.paste(this.copyData, pasteWorkspace);
+    //   },
+    //   keyCodes: [
+    //     createSerializedKey(KeyCodes.V, [KeyCodes.CTRL]),
+    //     createSerializedKey(KeyCodes.V, [KeyCodes.ALT]),
+    //     createSerializedKey(KeyCodes.V, [KeyCodes.META]),
+    //   ],
+    //   allowCollision: true,
+    // },
 
     /** Copy and delete the block the cursor is currently on. */
-    cut: {
-      name: Constants.SHORTCUT_NAMES.CUT,
-      preconditionFn: (workspace) => {
-        if (this.canCurrentlyEdit(workspace)) {
-          const curNode = workspace.getCursor()?.getCurNode();
-          if (curNode && curNode.getSourceBlock()) {
-            const sourceBlock = curNode.getSourceBlock();
-            return !!(
-              !Blockly.Gesture.inProgress() &&
-              sourceBlock &&
-              sourceBlock.isDeletable() &&
-              sourceBlock.isMovable() &&
-              !sourceBlock.workspace.isFlyout
-            );
-          }
-        }
-        return false;
-      },
-      callback: (workspace) => {
-        const sourceBlock = workspace
-          .getCursor()
-          ?.getCurNode()
-          .getSourceBlock() as BlockSvg;
-        this.copyData = sourceBlock.toCopyData();
-        this.copyWorkspace = sourceBlock.workspace;
-        this.navigation.moveCursorOnBlockDelete(workspace, sourceBlock);
-        sourceBlock.checkAndDelete();
-        return true;
-      },
-      keyCodes: [
-        createSerializedKey(KeyCodes.X, [KeyCodes.CTRL]),
-        createSerializedKey(KeyCodes.X, [KeyCodes.ALT]),
-        createSerializedKey(KeyCodes.X, [KeyCodes.META]),
-      ],
-      allowCollision: true,
-    },
+    // cut: {
+    //   name: Constants.SHORTCUT_NAMES.CUT,
+    //   preconditionFn: (workspace) => {
+    //     if (this.canCurrentlyEdit(workspace)) {
+    //       const curNode = workspace.getCursor()?.getCurNode();
+    //       if (curNode && curNode.getSourceBlock()) {
+    //         const sourceBlock = curNode.getSourceBlock();
+    //         return !!(
+    //           !Blockly.Gesture.inProgress() &&
+    //           sourceBlock &&
+    //           sourceBlock.isDeletable() &&
+    //           sourceBlock.isMovable() &&
+    //           !sourceBlock.workspace.isFlyout
+    //         );
+    //       }
+    //     }
+    //     return false;
+    //   },
+    //   callback: (workspace) => {
+    //     const sourceBlock = workspace
+    //       .getCursor()
+    //       ?.getCurNode()
+    //       .getSourceBlock() as BlockSvg;
+    //     this.copyData = sourceBlock.toCopyData();
+    //     this.copyWorkspace = sourceBlock.workspace;
+    //     this.navigation.moveCursorOnBlockDelete(workspace, sourceBlock);
+    //     sourceBlock.checkAndDelete();
+    //     return true;
+    //   },
+    //   keyCodes: [
+    //     createSerializedKey(KeyCodes.X, [KeyCodes.CTRL]),
+    //     createSerializedKey(KeyCodes.X, [KeyCodes.ALT]),
+    //     createSerializedKey(KeyCodes.X, [KeyCodes.META]),
+    //   ],
+    //   allowCollision: true,
+    // },
 
     /** List all of the currently registered shortcuts. */
     announceShortcuts: {
@@ -925,7 +931,10 @@ export class NavigationController {
       ShortcutRegistry.registry.register(shortcut);
     }
     this.deleteAction.install();
-    this.registerCopyAction();
+
+    this.clipboard.install();
+
+    //this.registerCopyAction();
     this.registerInsertAction();
 
     // Initalise the shortcut modal with available shortcuts.  Needs

--- a/src/navigation_controller.ts
+++ b/src/navigation_controller.ts
@@ -916,7 +916,7 @@ export class NavigationController {
       },
       scopeType: ContextMenuRegistry.ScopeType.BLOCK,
       id: 'insert',
-      weight: 12,
+      weight: 9,
     };
     ContextMenuRegistry.registry.register(insertAboveAction);
   }


### PR DESCRIPTION
### User facing changes

Fixes #217 by adding a cut option in the context menu on blocks
Fixes #218 by adding/updating the copy option in the context menu on blocks
Fixes #219 by adding a paste option in the context menu on blocks

Implements parts of #224 by organizing the context menu items and improving text
- Cut, Copy, Paste are in the correct relative order and have shortcut hints: `(Ctrl + X)` or similar
- Delete has a count and a shortcut hint: `(Del)`
- Removes text "`Keyboard Navigation: ` from copy and delete options
- Removes duplicate delete option
- Moves insert action above clipboard actions

### Additional bugs

While testing I found #233 and raised #232 for more complex copy behaviour. Current behaviour is not well-documented and probably not intentional.

### Structural changes

Moves the delete action to its own file, and the three clipboard actions to a shared file. Both classes have `install` and `uninstall` functions and keep track of state when necessary. This is work toward #155.

