### PR TITLE
fix: don't set cursor to disposed passiveFocusNode

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -403,9 +403,11 @@ export class Navigation {
     if (cursor) {
       const passiveFocusNode = this.passiveFocusIndicator.getCurNode();
       this.passiveFocusIndicator.hide();
-      // If there's a gesture then it will either set the node or be a click
+      const disposed = passiveFocusNode?.getSourceBlock()?.disposed;
+      // If there's a gesture then it will either set the node if it has not 
+      // been disposed (which can happen when blocks are reloaded) or be a click 
       // that should not set one.
-      if (!Blockly.Gesture.inProgress() && passiveFocusNode) {
+      if (!Blockly.Gesture.inProgress() && passiveFocusNode && !disposed) {
         cursor.setCurNode(passiveFocusNode);
       }
     }


### PR DESCRIPTION
Similar to the [previous fix](https://github.com/google/blockly-keyboard-experimentation/pull/271) for #146 

Checks whether passiveFocusNode has been disposed before setting it as current node


