### PR TITLE
chore: Extend delete tests with context menu actions.

### DIFF
--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -203,7 +203,7 @@ suite('Menus test', function () {
 
   test('Clicking workspace dismisses menu', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await rightClickOnBlock(this.browser, 'draw_circle_1');
+    await rightClickOnBlock(this.browser, 'create_canvas_1');
     await this.browser.pause(PAUSE_TIME);
     await focusWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -8,9 +8,13 @@ import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
   contextMenuExists,
+  getContextMenuItemNames,
   moveToToolboxCategory,
   PAUSE_TIME,
   focusOnBlock,
+  focusWorkspace,
+  rightClickOnBlock,
+  rightClickOnFlyoutBlockType,
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
@@ -27,6 +31,18 @@ suite('Menus test', function () {
     await this.browser.pause(PAUSE_TIME);
   });
 
+  test('Menu keyboard shortcut on workspace does not open menu', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.isTrue(
+      await contextMenuExists(this.browser, 'Undo', /* reverse= */ true),
+      'The menu should not be openable on the workspace',
+    );
+  });
+
   test('Menu action opens menu', async function () {
     // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
@@ -41,9 +57,7 @@ suite('Menus test', function () {
   });
 
   test('Menu action returns true in the toolbox', async function () {
-    // Navigate to draw_circle_1.
     await tabNavigateToWorkspace(this.browser);
-    await focusOnBlock(this.browser, 'draw_circle_1');
     // Navigate to a toolbox category
     await moveToToolboxCategory(this.browser, 'Functions');
     // Move to flyout.
@@ -68,6 +82,135 @@ suite('Menus test', function () {
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Duplicate', true),
       'The menu should not be openable during a move',
+    );
+  });
+
+  test('Block menu via keyboard displays expected items', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    await focusOnBlock(this.browser, 'draw_circle_1');
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.deepEqual(
+      await getContextMenuItemNames(this.browser),
+      [
+        'Duplicate',
+        'Add Comment',
+        'External Inputs',
+        'Collapse Block',
+        'Disable Block',
+        'Delete 2 Blocks',
+        'Move Block',
+        'Edit Block contents',
+        'Cut',
+        'Copy',
+        'Paste',
+      ],
+      'A block context menu should display certain items',
+    );
+  });
+
+  test('Block menu via mouse displays expected items', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    await rightClickOnBlock(this.browser, 'draw_circle_1');
+
+    chai.assert.deepEqual(
+      await getContextMenuItemNames(this.browser),
+      [
+        'Duplicate',
+        'Add Comment',
+        'External Inputs',
+        'Collapse Block',
+        'Disable Block',
+        'Delete 2 Blocks',
+        'Cut',
+        'Copy',
+        'Paste',
+      ],
+      'A block context menu should display certain items',
+    );
+  });
+
+  test('Shadow block menu via keyboard displays expected items', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    await focusOnBlock(this.browser, 'draw_circle_1_color');
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.deepEqual(
+      await getContextMenuItemNames(this.browser),
+      [
+        'Add Comment',
+        'Collapse Block',
+        'Disable Block',
+        'Help',
+        'Move Block',
+        'Cut',
+        'Copy',
+        'Paste',
+      ],
+      'A shadow block context menu should display certain items',
+    );
+  });
+
+  test('Flyout block menu via keyboard displays expected items', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    // Navigate to a toolbox category
+    await moveToToolboxCategory(this.browser, 'Functions');
+    // Move to flyout.
+    await keyRight(this.browser);
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.deepEqual(
+      await getContextMenuItemNames(this.browser),
+      ['Help', 'Move Block', 'Cut', 'Copy', 'Paste'],
+      'A flyout block context menu should display certain items',
+    );
+  });
+
+  test('Flyout block menu via mouse displays expected items', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    // Navigate to a toolbox category
+    await moveToToolboxCategory(this.browser, 'Math');
+    // Move to flyout.
+    await keyRight(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+    await rightClickOnFlyoutBlockType(this.browser, 'math_number');
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.deepEqual(
+      await getContextMenuItemNames(this.browser),
+      ['Help', 'Cut', 'Copy', 'Paste'],
+      'A flyout block context menu should display certain items',
+    );
+  });
+
+  test('Escape key dismisses menu', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    await focusOnBlock(this.browser, 'draw_circle_1');
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys([Key.Ctrl, Key.Return]);
+    await this.browser.pause(PAUSE_TIME);
+    await this.browser.keys(Key.Escape);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.isTrue(
+      await contextMenuExists(this.browser, 'Duplicate', /* reverse= */ true),
+      'The menu should be closed',
+    );
+  });
+
+  test('Clicking workspace dismisses menu', async function () {
+    await tabNavigateToWorkspace(this.browser);
+    await rightClickOnBlock(this.browser, 'draw_circle_1');
+    await this.browser.pause(PAUSE_TIME);
+    await focusWorkspace(this.browser);
+    await this.browser.pause(PAUSE_TIME);
+
+    chai.assert.isTrue(
+      await contextMenuExists(this.browser, 'Duplicate', /* reverse= */ true),
+      'The menu should be closed',
     );
   });
 });

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -7,10 +7,13 @@
 import * as chai from 'chai';
 import {
   blockIsPresent,
+  clickOnAction,
+  doActionViaKeyboard,
   focusOnBlock,
   getCurrentFocusedBlockId,
   getFocusedBlockType,
   moveToToolboxCategory,
+  rightClickOnBlock,
   testSetup,
   testFileLocations,
   PAUSE_TIME,
@@ -24,213 +27,154 @@ suite('Deleting Blocks', function () {
   // Setting timeout to unlimited as these tests take a longer time to run than most mocha test
   this.timeout(0);
 
+  const deletionStrategies = [
+    {
+      strategyName: 'backspace',
+      deletionStrategy: async (browser: WebdriverIO.Browser) =>
+        await browser.keys(Key.Backspace),
+    },
+    {
+      strategyName: 'cut',
+      deletionStrategy: async (browser: WebdriverIO.Browser) =>
+        await browser.keys([Key.Ctrl, 'x']),
+    },
+    {
+      strategyName: 'keyboard action',
+      deletionStrategy: async (browser: WebdriverIO.Browser) => {
+        await browser.keys([Key.Ctrl, Key.Return]);
+        await doActionViaKeyboard(browser, 'Delete');
+      },
+    },
+    {
+      strategyName: 'mouse action',
+      deletionStrategy: async (browser: WebdriverIO.Browser) => {
+        const blockIdToDelete = await getCurrentFocusedBlockId(browser);
+        if (blockIdToDelete) {
+          await rightClickOnBlock(browser, blockIdToDelete);
+          await clickOnAction(browser, 'Delete');
+        }
+      },
+    },
+  ];
+
   setup(async function () {
     this.browser = await testSetup(testFileLocations.NAVIGATION_TEST_BLOCKS);
     await this.browser.pause(PAUSE_TIME);
   });
 
-  test('Deleting block selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-    await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+  for (const {strategyName, deletionStrategy} of deletionStrategies) {
+    test(`Deleting block via ${strategyName} selects parent block`, async function () {
+      await tabNavigateToWorkspace(this.browser);
+      await this.browser.pause(PAUSE_TIME);
+      await focusOnBlock(this.browser, 'controls_if_2');
+      await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'controls_if_2'))
-      .equal(true);
+      chai
+        .expect(await blockIsPresent(this.browser, 'controls_if_2'))
+        .equal(true);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+      await deletionStrategy(this.browser);
+      await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'controls_if_2'))
-      .equal(false);
+      chai
+        .expect(await blockIsPresent(this.browser, 'controls_if_2'))
+        .equal(false);
 
-    chai
-      .expect(await getCurrentFocusedBlockId(this.browser))
-      .to.include('controls_if_1');
-  });
+      chai
+        .expect(await getCurrentFocusedBlockId(this.browser))
+        .to.include('controls_if_1');
+    });
 
-  test('Cutting block selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-    await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+    test(`Deleting block via ${strategyName} also deletes children and inputs`, async function () {
+      await tabNavigateToWorkspace(this.browser);
+      await this.browser.pause(PAUSE_TIME);
+      await focusOnBlock(this.browser, 'controls_if_2');
+      await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'controls_if_2'))
-      .equal(true);
+      chai
+        .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
+        .equal(true);
+      chai
+        .expect(await blockIsPresent(this.browser, 'text_print_1'))
+        .equal(true);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+      await deletionStrategy(this.browser);
+      await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'controls_if_2'))
-      .equal(false);
+      chai
+        .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
+        .equal(false);
+      chai
+        .expect(await blockIsPresent(this.browser, 'text_print_1'))
+        .equal(false);
+    });
 
-    chai
-      .expect(await getCurrentFocusedBlockId(this.browser))
-      .to.include('controls_if_1');
-  });
+    test(`Deleting inline input via ${strategyName} selects parent block`, async function () {
+      await tabNavigateToWorkspace(this.browser);
+      await this.browser.pause(PAUSE_TIME);
+      await focusOnBlock(this.browser, 'logic_boolean_1');
+      await this.browser.pause(PAUSE_TIME);
 
-  test('Deleting block also deletes children and inputs', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-    await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+      chai
+        .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
+        .equal(true);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(true);
-    chai.expect(await blockIsPresent(this.browser, 'text_print_1')).equal(true);
+      await deletionStrategy(this.browser);
+      await this.browser.pause(PAUSE_TIME);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+      chai
+        .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
+        .equal(false);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(false);
-    chai
-      .expect(await blockIsPresent(this.browser, 'text_print_1'))
-      .equal(false);
-  });
+      chai
+        .expect(await getCurrentFocusedBlockId(this.browser))
+        .to.include('controls_if_2');
+    });
 
-  test('Cutting block also removes children and inputs', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-    await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+    test(`Deleting stranded block via ${strategyName} selects top block`, async function () {
+      // Deleting a stranded block should result in the workspace being
+      // focused, which then focuses the top block. If that
+      // behavior ever changes, this test should be updated as well.
+      // We want deleting a block to focus the workspace, whatever that
+      // means at the time.
+      await tabNavigateToWorkspace(this.browser);
+      await this.browser.pause(PAUSE_TIME);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(true);
-    chai.expect(await blockIsPresent(this.browser, 'text_print_1')).equal(true);
+      // The test workspace doesn't already contain a stranded block, so add one.
+      await moveToToolboxCategory(this.browser, 'Math');
+      await this.browser.pause(PAUSE_TIME);
+      // Move to flyout.
+      await keyRight(this.browser);
+      // Select number block.
+      await this.browser.keys(Key.Enter);
+      await this.browser.pause(PAUSE_TIME);
+      // Confirm move.
+      await this.browser.keys(Key.Enter);
+      await this.browser.pause(PAUSE_TIME);
 
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
+      chai.assert.equal('math_number', await getFocusedBlockType(this.browser));
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(false);
-    chai
-      .expect(await blockIsPresent(this.browser, 'text_print_1'))
-      .equal(false);
-  });
+      await deletionStrategy(this.browser);
+      await this.browser.pause(PAUSE_TIME);
 
-  test('Deleting inline input selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-    await focusOnBlock(this.browser, 'logic_boolean_1');
-    await this.browser.pause(PAUSE_TIME);
+      chai.assert.equal(
+        await getCurrentFocusedBlockId(this.browser),
+        'p5_setup_1',
+      );
+    });
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(true);
+    test(`Do not delete block via ${strategyName} while field editor is open`, async function () {
+      // Open a field editor
+      await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
+      await this.browser.pause(PAUSE_TIME);
+      await this.browser.keys(Key.Enter);
+      await this.browser.pause(PAUSE_TIME);
 
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
+      // Try to delete block while field editor is open
+      await deletionStrategy(this.browser);
 
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(false);
-
-    chai
-      .expect(await getCurrentFocusedBlockId(this.browser))
-      .to.include('controls_if_2');
-  });
-
-  test('Cutting inline input selects parent block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-    await focusOnBlock(this.browser, 'logic_boolean_1');
-    await this.browser.pause(PAUSE_TIME);
-
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(true);
-
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
-
-    chai
-      .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
-      .equal(false);
-
-    chai
-      .expect(await getCurrentFocusedBlockId(this.browser))
-      .to.include('controls_if_2');
-  });
-
-  test('Deleting stranded block selects top block', async function () {
-    // Deleting a stranded block should result in the workspace being
-    // focused, which then focuses the top block. If that
-    // behavior ever changes, this test should be updated as well.
-    // We want deleting a block to focus the workspace, whatever that
-    // means at the time.
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-
-    // The test workspace doesn't already contain a stranded block, so add one.
-    await moveToToolboxCategory(this.browser, 'Math');
-    await this.browser.pause(PAUSE_TIME);
-    // Move to flyout.
-    await keyRight(this.browser);
-    // Select number block.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
-    // Confirm move.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
-
-    chai.assert.equal('math_number', await getFocusedBlockType(this.browser));
-
-    await this.browser.keys(Key.Backspace);
-    await this.browser.pause(PAUSE_TIME);
-
-    chai.assert.equal(
-      await getCurrentFocusedBlockId(this.browser),
-      'p5_setup_1',
-    );
-  });
-
-  test('Cutting stranded block selects top block', async function () {
-    await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
-
-    // The test workspace doesn't already contain a stranded block, so add one.
-    await moveToToolboxCategory(this.browser, 'Math');
-    await this.browser.pause(PAUSE_TIME);
-    // Move to flyout.
-    await keyRight(this.browser);
-    // Select number block.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
-    // Confirm move.
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
-
-    chai.assert.equal('math_number', await getFocusedBlockType(this.browser));
-
-    await this.browser.keys([Key.Ctrl, 'x']);
-    await this.browser.pause(PAUSE_TIME);
-
-    chai.assert.equal(
-      await getCurrentFocusedBlockId(this.browser),
-      'p5_setup_1',
-    );
-  });
-
-  test('Do not delete block while field editor is open', async function () {
-    // Open a field editor
-    await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
-    await this.browser.pause(PAUSE_TIME);
-    await this.browser.keys(Key.Enter);
-    await this.browser.pause(PAUSE_TIME);
-
-    // Try to delete block while field editor is open
-    await this.browser.keys(Key.Backspace);
-
-    // Block is not deleted
-    chai.assert.isTrue(await blockIsPresent(this.browser, 'colour_picker_1'));
-  });
+      // Block is not deleted
+      chai.assert.isTrue(await blockIsPresent(this.browser, 'colour_picker_1'));
+    });
+  }
 });

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -504,7 +504,7 @@ export async function isDragging(
 }
 
 /**
- * Returns the result of the specificied action precondition.
+ * Returns the result of the specified action precondition.
  *
  * @param browser The active WebdriverIO Browser object.
  * @param action The action to check the precondition for.
@@ -554,4 +554,50 @@ export async function contextMenuExists(
 ): Promise<boolean> {
   const item = await browser.$(`div=${itemText}`);
   return await item.waitForExist({timeout: 200, reverse: reverse});
+}
+
+/**
+ * Get a list of the text content of each displayed context menu item.
+ *
+ * Omits any keyboard shortcuts inside parentheses from all item text for
+ * testing consistency across platforms.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @return A list of the text content of each displayed context menu item.
+ */
+export async function getContextMenuItemNames(
+  browser: WebdriverIO.Browser,
+): Promise<string[]> {
+  const items = await browser.$$(`.blocklyContextMenu .blocklyMenuItemContent`);
+  return await items.map(async (e) =>
+    (await e.getText()).replace(/\s*\([^)]+\)/, ''),
+  );
+}
+
+/**
+ * Right-clicks on a block with the provided ID in the main workspace.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param blockId The ID of the block to right click on.
+ */
+export async function rightClickOnBlock(
+  browser: WebdriverIO.Browser,
+  blockId: string,
+) {
+  const elem = await browser.$(`[data-id="${blockId}"]`);
+  await elem.click({button: 'right'});
+}
+
+/**
+ * Right-clicks on a block with the provided type in the flyout.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ * @param blockType The name of the type block to right click on.
+ */
+export async function rightClickOnFlyoutBlockType(
+  browser: WebdriverIO.Browser,
+  blockType: string,
+) {
+  const elem = await browser.$(`.blocklyFlyout .${blockType}`);
+  await elem.click({button: 'right'});
 }


### PR DESCRIPTION
Refactors the existing deletion tests to run the same tests with multiple deletion strategies. The existing deletion strategies were backspace and ctrl+X, and now I've added deleting using the context menu, either via keyboard or mouse. 

This PR is based on https://github.com/google/blockly-keyboard-experimentation/pull/575 and includes those changes, so please review that first, then we can reconcile with this PR to see which changes are left.