### PR TITLE
fix: Fix bug that prevented navigating into and within flyouts.

### DIFF
--- a/src/actions/arrow_navigation.ts
+++ b/src/actions/arrow_navigation.ts
@@ -79,7 +79,6 @@ export class ArrowNavigation {
           // @ts-expect-error private method
           isHandled = toolbox && toolbox.selectChild();
           if (!isHandled && flyout) {
-            Blockly.getFocusManager().focusTree(flyout.getWorkspace());
             this.navigation.defaultFlyoutCursorIfNeeded(workspace);
           }
           return true;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -306,8 +306,13 @@ export class Navigation {
 
     const curNode = flyoutCursor.getCurNode();
     const sourceBlock = flyoutCursor.getSourceBlock();
-    if (curNode && !this.isFlyoutItemDisposed(curNode, sourceBlock))
+    if (
+      curNode &&
+      curNode.getFocusableTree() === flyout.getWorkspace() &&
+      !this.isFlyoutItemDisposed(curNode, sourceBlock)
+    ) {
       return false;
+    }
 
     const flyoutContents = flyout.getContents();
     const defaultFlyoutItem =

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -306,8 +306,10 @@ export class Navigation {
 
     const curNode = flyoutCursor.getCurNode();
     const sourceBlock = flyoutCursor.getSourceBlock();
+    // If the current node is a child of the flyout, nothing needs to be done.
     if (
       curNode &&
+      curNode !== flyout.getWorkspace() &&
       curNode.getFocusableTree() === flyout.getWorkspace() &&
       !this.isFlyoutItemDisposed(curNode, sourceBlock)
     ) {


### PR DESCRIPTION
This PR fixes #601 and fixes #602. When the cursor was updated to no longer have its own current node, the underlying assumption that the flyout cursor having a non-null current node implied that something was selected in the flyout was violated, since it would now return whatever is focused, even if that is outside of the flyout. Now, the returned item is checked to see if it is actually a child of the flyout's focus tree, and if not, the first item in the flyout is selected.