### PR TITLE
fix: Fix display of workspace focus ring in move mode.

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -146,6 +146,9 @@
         .blocklyWorkspace:has(.blocklyActiveFocus)
         .blocklyWorkspaceFocusRing,
       .blocklyKeyboardNavigation
+        .blocklySvg:has(~ .blocklyBlockDragSurface .blocklyActiveFocus)
+        .blocklyWorkspaceFocusRing,
+      .blocklyKeyboardNavigation
         .blocklyWorkspace.blocklyActiveFocus
         .blocklyWorkspaceFocusRing {
         stroke: var(--blockly-active-tree-color);


### PR DESCRIPTION
This PR fixes #569 (the first half) by updating the stylesheet as suggested by @microbit-matt-hillsdon . The latter half of the bug appears to have been incidentally fixed at some earlier point. 