### PR TITLE
chore: upgrade field colour to buggy version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@blockly/dev-scripts": "^4.0.8",
-        "@blockly/field-colour": "^6.0.0",
+        "@blockly/field-colour": "^6.0.2",
         "@eslint/eslintrc": "^2.1.2",
         "@eslint/js": "^8.49.0",
         "@types/chai": "^5.2.1",
@@ -977,12 +977,27 @@
       }
     },
     "node_modules/@blockly/field-colour": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.0.tgz",
-      "integrity": "sha512-cKmXb4YMpr29a5a34bMOh5gpVv3Fh19tpEeSAy6V+LhOpEx3DQ57Ch8wEcC8K37fvCUp9tMtzcL2OXBT5LtdNA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@blockly/field-colour/-/field-colour-6.0.2.tgz",
+      "integrity": "sha512-IJMGKei53+n9Ld5kFxpMptq6KxeJ8sbrWF+YWqH5f4nMojiOhvGK8dkuM0s69OiiHByPr5YBIr1+aZQReKnN3Q==",
       "dev": true,
+      "dependencies": {
+        "@blockly/field-grid-dropdown": "^6.0.1"
+      },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "blockly": "^12.0.0"
+      }
+    },
+    "node_modules/@blockly/field-grid-dropdown": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@blockly/field-grid-dropdown/-/field-grid-dropdown-6.0.1.tgz",
+      "integrity": "sha512-Y3H5Z4A4cwhbIqP2pWJNTIGoCiKtYUdveZk8U83wGk9goQL2cUgQ4jfpEaxjfZVG+VG4mBwVV4nZHFDc6cJJJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.17.0"
       },
       "peerDependencies": {
         "blockly": "^12.0.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "devDependencies": {
     "@blockly/dev-scripts": "^4.0.8",
-    "@blockly/field-colour": "^6.0.0",
+    "@blockly/field-colour": "^6.0.2",
     "@eslint/eslintrc": "^2.1.2",
     "@eslint/js": "^8.49.0",
     "@types/chai": "^5.2.1",


### PR DESCRIPTION
This illustrates that the latest version, based on field-grid-dropdown, does not work with keyboard navigation enabled. This is because Enter propagates to the global shortcut handler, causing the field editor to be retriggered or block toast messages to be shown.

On reflection I think this is actually a plugin bug surfaced by recent changes to field-colour. I'll open a PR shortly.

Demo link: https://upgrade-field-colour.blockly-keyboard-experimentation.pages.dev/