### PR TITLE
fix: default stationary node when inserting a block

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -185,7 +185,10 @@ export class EnterAction {
       Events.setGroup(true);
     }
 
-    const stationaryNode = FocusableTreeTraverser.findFocusedNode(workspace);
+    // If the workspace has never had focus default the stationary node.
+    const stationaryNode =
+      FocusableTreeTraverser.findFocusedNode(workspace) ??
+      workspace.getRestoredFocusableNode(null);
     const newBlock = this.createNewBlock(workspace);
     if (!newBlock) return;
     const insertStartPoint = stationaryNode

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -15,6 +15,8 @@ import {
   testFileLocations,
   testSetup,
   keyRight,
+  keyUp,
+  tabNavigateToToolbox,
 } from './test_setup.js';
 
 suite('Insert test', function () {
@@ -42,6 +44,25 @@ suite('Insert test', function () {
 
     chai.assert.equal(
       'procedures_defnoreturn',
+      await getFocusedBlockType(this.browser),
+    );
+  });
+
+  test('Insert without having focused the workspace', async function () {
+    await tabNavigateToToolbox(this.browser);
+
+    // Insert 'if' block
+    await keyRight(this.browser);
+    // Choose.
+    await this.browser.keys(Key.Enter);
+    // Confirm position.
+    await this.browser.keys(Key.Enter);
+
+    // Assert inserted inside first block p5_setup not at top-level.
+    chai.assert.equal('controls_if', await getFocusedBlockType(this.browser));
+    await keyUp(this.browser);
+    chai.assert.equal(
+      'p5_background_color',
       await getFocusedBlockType(this.browser),
     );
   });

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -425,6 +425,19 @@ export async function tabNavigateToWorkspace(
 }
 
 /**
+ * Uses tabs to navigate to the toolbox on the test page (i.e. by going
+ * through top-level tab stops). Assumes initial load tab position.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ */
+export async function tabNavigateToToolbox(browser: WebdriverIO.Browser) {
+  // Initial pre-injection focusable div element.
+  await tabNavigateForward(browser);
+  // Toolbox.
+  await tabNavigateForward(browser);
+}
+
+/**
  * Navigates forward to the test page's next tab stop.
  *
  * @param browser The active WebdriverIO Browser object.


### PR DESCRIPTION
It can be null if the workspace has never taken focus but it's unhelpful to behave as if the user had selected the workspace itself (as via 'w'). Use the same logic as the workspace would use if it had taken focus, which will return the first block.

Fixes #629

CC @BenHenning in case there's any downside to this I'm not seeing.
