### PR TITLE
fix: Allow workspace comments to be moved in constrained mode.

### DIFF
--- a/src/actions/mover.ts
+++ b/src/actions/mover.ts
@@ -318,6 +318,10 @@ export class Mover {
     const info = this.moves.get(workspace);
     if (!info) throw new Error('no move info for workspace');
 
+    if (info.draggable instanceof comments.RenderedWorkspaceComment) {
+      return this.moveUnconstrained(workspace, direction);
+    }
+
     info.dragger.onDrag(
       info.fakePointerEvent('pointermove', direction),
       info.totalDelta.clone().scale(workspace.scale),

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -189,7 +189,7 @@ suite('Workspace comment navigation', function () {
     );
   });
 
-  test('Workspace comments can be moved', async function () {
+  test('Workspace comments can be moved in unconstrained mode', async function () {
     await focusOnWorkspaceComment(this.browser, this.commentId1);
 
     const initialPosition = await this.getCommentLocation(this.commentId1);
@@ -202,5 +202,20 @@ suite('Workspace comment navigation', function () {
 
     const newPosition = await this.getCommentLocation(this.commentId1);
     chai.assert.deepEqual(newPosition, [220, 240]);
+  });
+
+  test('Workspace comments can be moved in constrained mode', async function () {
+    await focusOnWorkspaceComment(this.browser, this.commentId1);
+
+    const initialPosition = await this.getCommentLocation(this.commentId1);
+    chai.assert.deepEqual(initialPosition, [200, 200]);
+
+    await sendKeyAndWait(this.browser, 'm');
+    await sendKeyAndWait(this.browser, Key.ArrowUp, 2);
+    await sendKeyAndWait(this.browser, Key.ArrowLeft);
+    await sendKeyAndWait(this.browser, Key.Enter);
+
+    const newPosition = await this.getCommentLocation(this.commentId1);
+    chai.assert.deepEqual(newPosition, [180, 160]);
   });
 });

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -211,8 +211,8 @@ suite('Workspace comment navigation', function () {
     chai.assert.deepEqual(initialPosition, [200, 200]);
 
     await sendKeyAndWait(this.browser, 'm');
-    await sendKeyAndWait(this.browser, Key.ArrowUp, 2);
-    await sendKeyAndWait(this.browser, Key.ArrowLeft);
+    await keyUp(this.browser, 2);
+    await keyLeft(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     const newPosition = await this.getCommentLocation(this.commentId1);


### PR DESCRIPTION
This PR allows workspace comments to be moved in "constrained" mode via the arrow keys without modifiers. Since workspace comments can be placed anywhere, this just passes through to unconstrained movement. This addresses a point of feedback raised in https://github.com/google/blockly-keyboard-experimentation/pull/625.