### PR TITLE
fix: clean up shortcut help dialog

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export enum SHORTCUT_NAMES {
   LEFT = 'left',
   NEXT_STACK = 'next_stack',
   PREVIOUS_STACK = 'previous_stack',
+  // Unused.
   INSERT = 'insert',
   EDIT_OR_CONFIRM = 'edit_or_confirm',
   DISCONNECT = 'disconnect',
@@ -52,7 +53,15 @@ export enum SHORTCUT_NAMES {
   CREATE_WS_CURSOR = 'to_workspace',
   LIST_SHORTCUTS = 'list_shortcuts',
   CLEAN_UP = 'clean_up_workspace',
+  START_MOVE = 'start_move',
 }
+
+export const SHORTCUT_NAMES_TO_DISPLAY_TEXT: Record<string, string> = {
+  'keyboard_nav_copy': Msg['Copy'] || 'Copy',
+  'keyboard_nav_cut': Msg['Cut'] || 'Cut',
+  'keyboard_nav_paste': Msg['Paste'] || 'Paste',
+  'start_move': Msg['MOVE_BLOCK'] || 'Move',
+};
 
 /**
  * Types of possible messages passed into the loggingCallback in the Navigation
@@ -73,7 +82,7 @@ export const SHORTCUT_CATEGORIES: Record<
   // Also allow undo/redo. Document the non-keyboard-nav versions of others for
   // better text because temporarily the name in the table is derived from
   // these id-like names.
-  Array<SHORTCUT_NAMES | 'undo' | 'redo' | 'cut' | 'copy' | 'paste' | 'delete'>
+  Array<SHORTCUT_NAMES | 'undo' | 'redo' | 'delete'>
 > = {};
 
 SHORTCUT_CATEGORIES[Msg['SHORTCUTS_GENERAL']] = [
@@ -86,12 +95,12 @@ SHORTCUT_CATEGORIES[Msg['SHORTCUTS_GENERAL']] = [
 ];
 
 SHORTCUT_CATEGORIES[Msg['SHORTCUTS_EDITING']] = [
-  SHORTCUT_NAMES.INSERT,
   'delete',
   SHORTCUT_NAMES.DISCONNECT,
-  'cut',
-  'copy',
-  'paste',
+  SHORTCUT_NAMES.START_MOVE,
+  SHORTCUT_NAMES.CUT,
+  SHORTCUT_NAMES.COPY,
+  SHORTCUT_NAMES.PASTE,
   SHORTCUT_NAMES.DUPLICATE,
   'undo',
   'redo',
@@ -104,4 +113,5 @@ SHORTCUT_CATEGORIES[Msg['SHORTCUTS_CODE_NAVIGATION']] = [
   SHORTCUT_NAMES.LEFT,
   SHORTCUT_NAMES.NEXT_STACK,
   SHORTCUT_NAMES.PREVIOUS_STACK,
+  SHORTCUT_NAMES.CREATE_WS_CURSOR,
 ];

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -95,7 +95,30 @@ export class ShortcutDialog {
    * List all currently registered shortcuts as a table.
    */
   createModalContent() {
-    let modalContents = `<div class="modal-container">
+    let shortcutTables = ``;
+
+    // Display shortcuts by their categories.
+    for (const [key, categoryShortcuts] of Object.entries(
+      Constants.SHORTCUT_CATEGORIES,
+    )) {
+      let shortcutTableRows = ``;
+      for (const keyboardShortcut of categoryShortcuts) {
+        shortcutTableRows += `
+              <tr>
+                <td>${this.getReadableShortcutName(keyboardShortcut)}</td>
+                <td>${this.actionShortcutsToHTML(keyboardShortcut)}</td>
+              </tr>`;
+      }
+      shortcutTables += `
+        <table class="shortcut-table">
+          <tbody>
+            <tr class="category"><th colspan="3"><h2>${key}</h2></th></tr>
+            ${shortcutTableRows}
+          </tbody>
+        </table>`;
+    }
+
+    const modalContents = `<div class="modal-container">
       <dialog class="shortcut-modal">
         <div class="shortcut-container" tabindex="0">
           <div class="header">
@@ -104,33 +127,13 @@ export class ShortcutDialog {
             </button>
             <h1>Keyboard shortcuts – <span class="platform">Windows</span></h1>
           </div>
-          <div class="shortcut-tables">`;
-
-    // Display shortcuts by their categories.
-    for (const [key, categoryShortcuts] of Object.entries(
-      Constants.SHORTCUT_CATEGORIES,
-    )) {
-      modalContents += `
-        <table class="shortcut-table">
-          <tbody>
-          <tr class="category"><th colspan="3"><h2>${key}</h2></th></tr>
-          <tr>
-          `;
-
-      for (const keyboardShortcut of categoryShortcuts) {
-        modalContents += `
-              <td>${this.getReadableShortcutName(keyboardShortcut)}</td>
-              <td>${this.actionShortcutsToHTML(keyboardShortcut)}</td>
-              </tr>`;
-      }
-      modalContents += '</tr></tbody></table>';
-    }
+          <div class="shortcut-tables">
+          ${shortcutTables}
+          </div>
+        </dialog>
+      </div>`;
     if (this.outputDiv) {
-      this.outputDiv.innerHTML =
-        modalContents +
-        `</div>
-      </dialog>
-    </div>`;
+      this.outputDiv.innerHTML = modalContents;
       this.modalContainer = this.outputDiv.querySelector('.modal-container');
       this.shortcutDialog = this.outputDiv.querySelector('.shortcut-modal');
       this.closeButton = this.outputDiv.querySelector('.close-modal');

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -52,19 +52,6 @@ export class ShortcutDialog {
     }
   }
 
-  /**
-   * Update the modifier key to the user's specific platform.
-   */
-  updatePlatformName() {
-    const platform = this.getPlatform();
-    const platformEl = this.outputDiv
-      ? this.outputDiv.querySelector('.platform')
-      : null;
-    if (platformEl) {
-      platformEl.textContent = platform;
-    }
-  }
-
   toggle(workspace: Blockly.WorkspaceSvg) {
     clearHelpHint(workspace);
     this.toggleInternal();
@@ -126,7 +113,7 @@ export class ShortcutDialog {
             <button class="close-modal">
               <span class="material-symbols-outlined">close</span>
             </button>
-            <h1>Keyboard shortcuts – <span class="platform">Windows</span></h1>
+            <h1>${Msg['SHORTCUTS_HELP_HEADER'] || 'Keyboard shortcuts'} – <span class="platform">${this.getPlatform()}</span></h1>
           </div>
           <div class="shortcut-tables">
           ${shortcutTables}
@@ -138,8 +125,6 @@ export class ShortcutDialog {
       this.modalContainer = this.outputDiv.querySelector('.modal-container');
       this.shortcutDialog = this.outputDiv.querySelector('.shortcut-modal');
       this.closeButton = this.outputDiv.querySelector('.close-modal');
-      this.updatePlatformName();
-      // Can we also intercept the Esc key to dismiss.
       if (this.closeButton) {
         this.closeButton.addEventListener('click', (e) => {
           this.toggleInternal();

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -103,11 +103,9 @@ export class ShortcutDialog {
     )) {
       let shortcutTableRows = ``;
       for (const keyboardShortcut of categoryShortcuts) {
-        shortcutTableRows += `
-              <tr>
-                <td>${this.getReadableShortcutName(keyboardShortcut)}</td>
-                <td>${this.actionShortcutsToHTML(keyboardShortcut)}</td>
-              </tr>`;
+        shortcutTableRows += this.getTableRowForShortcut(
+          keyboardShortcut as string,
+        );
       }
       shortcutTables += `
         <table class="shortcut-table">
@@ -147,13 +145,25 @@ export class ShortcutDialog {
     }
   }
 
-  private actionShortcutsToHTML(action: string) {
-    const shortcuts = getLongActionShortcutsAsKeys(action);
-    return shortcuts.map((keys) => this.actionShortcutToHTML(keys)).join(' / ');
+  private getTableRowForShortcut(keyboardShortcut: string) {
+    const name = this.getReadableShortcutName(keyboardShortcut);
+    const keys = this.actionShortcutsToHTML(keyboardShortcut);
+    if (!name || !keys) return '';
+    return `
+              <tr>
+                <td>${name}</td>
+                <td>${keys}</td>
+              </tr>`;
   }
 
-  private actionShortcutToHTML(keys: string[]) {
+  private actionShortcutsToHTML(action: string) {
+    const shortcuts = getLongActionShortcutsAsKeys(action);
+    return shortcuts.map((keys) => this.keysToHTML(keys)).join(' / ');
+  }
+
+  private keysToHTML(keys: string[]) {
     const separator = navigator.platform.startsWith('Mac') ? '' : ' + ';
+    if (!keys || !keys.length) return [];
     return [
       `<span class="shortcut-combo">`,
       ...keys.map((key, index) => {

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -151,7 +151,7 @@ export class ShortcutDialog {
 
   private keysToHTML(keys: string[]) {
     const separator = navigator.platform.startsWith('Mac') ? '' : ' + ';
-    if (!keys || !keys.length) return [];
+    if (!keys || !keys.length) return '';
     return [
       `<span class="shortcut-combo">`,
       ...keys.map((key, index) => {

--- a/src/shortcut_dialog.ts
+++ b/src/shortcut_dialog.ts
@@ -88,6 +88,9 @@ export class ShortcutDialog {
    * @returns A title case version of the name.
    */
   getReadableShortcutName(shortcutName: string) {
+    if (Constants.SHORTCUT_NAMES_TO_DISPLAY_TEXT[shortcutName]) {
+      return Constants.SHORTCUT_NAMES_TO_DISPLAY_TEXT[shortcutName];
+    }
     return upperCaseFirst(shortcutName.replace(/_/gi, ' '));
   }
 


### PR DESCRIPTION
Fixes #654 

This PR has multiple commits that may be easier to review individually.

- Rearranges the HTML to use some template tags and variables instead of concatenating HTML. I find this easier to read and make sure tags are all closed, etc.
- Hides shortcuts from the table that don't have any keys displayed. This makes the dialog more resilient to things going out of date (e.g. the insert shortcut being removed) and also makes it more useful for people who have customized things by removing certain shortcuts for whatever reason.
- Introduces a conversion between shortcut name and display name, to account for the fact that clipboard shortcuts are called `keyboard_nav_copy` etc. but shouldn't be displayed that way.
- Uses `Blockly.Msg` for the header of the dialog
- Removes the insert shortcut which no longer exists
- Adds the jump to workspace & move shortcuts
- Fixes the cut/copy/paste shortcuts so they display correctly
