### PR TITLE
test(`MoveActions`): Test starting a move using the context menu

### DIFF
--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -15,6 +15,7 @@ import {
   testSetup,
   sendKeyAndWait,
   keyDown,
+  contextMenuItems,
 } from './test_setup.js';
 
 suite('Move tests', function () {
@@ -33,6 +34,8 @@ suite('Move tests', function () {
   // moved, with subsequent statement blocks below it in the stack
   // reattached to where the moving block was - i.e., that a stack
   // heal will occur.
+  //
+  // Also tests initating a move using the shortcut key.
   test('Start moving statement blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
@@ -50,7 +53,7 @@ suite('Move tests', function () {
       );
       chai.assert(info.nextId, 'selected block has no next block');
 
-      // Start move.
+      // Start move using keyboard shortcut.
       await sendKeyAndWait(this.browser, 'm');
 
       // Check that the moving block has nothing connected it its
@@ -93,6 +96,8 @@ suite('Move tests', function () {
   // When a move of a value block begins, it is expected that block
   // and all blocks connected to its inputs will be moved - i.e., that
   // a stack heal (really: unary operator chain heal) will NOT occur.
+  //
+  // Also tests initiating a move via the context menu.
   test('Start moving value blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
@@ -110,8 +115,16 @@ suite('Move tests', function () {
       );
       chai.assert(info.valueId, 'selected block has no child value block');
 
-      // Start move.
+      // Start move using context menu (using keyboard nav).
+      await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
       await sendKeyAndWait(this.browser, 'm');
+      await keyDown(
+        this.browser,
+        (await contextMenuItems(this.browser)).findIndex(({text}) =>
+          text.includes('Move'),
+        ),
+      );
+      await sendKeyAndWait(this.browser, Key.Return);
 
       // Check that the moving block has nothing connected it its
       // next/previous connections, and same thing connected to value

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -552,9 +552,15 @@ export async function sendKeyAndWait(
   keys: string | string[],
   times = 1,
 ) {
-  for (let i = 0; i < times; i++) {
+  if (PAUSE_TIME === 0) {
+    // Send all keys in one call if no pauses needed.
+    keys = Array(times).fill(keys).flat();
     await browser.keys(keys);
-    await browser.pause(PAUSE_TIME);
+  } else {
+    for (let i = 0; i < times; i++) {
+      await browser.keys(keys);
+      await browser.pause(PAUSE_TIME);
+    }
   }
 }
 


### PR DESCRIPTION
Modify one of the existing move start tests to initiate the move using the context menu (using keyboard nav), rather than the keyboard shortcut.

Also make `sendKeyAndWait` faster when sending repeated keys.

Fixes #695.
