### PR TITLE
refactor(tests): Refactor move tests to simplify `moveTest` helper

### DIFF
--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -558,6 +558,7 @@ export async function sendKeyAndWait(
   keys: string | string[],
   times = 1,
 ) {
+  // @ts-ignore: Unintentional comparison error
   if (PAUSE_TIME === 0) {
     // Send all keys in one call if no pauses needed.
     keys = Array(times).fill(keys).flat();

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -558,6 +558,7 @@ export async function sendKeyAndWait(
   keys: string | string[],
   times = 1,
 ) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore: Unintentional comparison error
   if (PAUSE_TIME === 0) {
     // Send all keys in one call if no pauses needed.


### PR DESCRIPTION
Two tweaks to PR #704 in preparation for adding more move tests:

* Add a `// @ts-ignore` to suppress an Unintended Comparison error that can occur when `PAUSE_TIME` is set to a value other than `0`.
* Modify the `moveTest` helper: by assuming that the moving block always finishes at the same location it starts, it's possible to considerably simplify the tests that call it.
  * Tests to verify correct reconnection after end of move (e.g. healing) will be done in a separate suite as part of #699.

Part of #696.
