### PR TITLE
test(`Mover`): Add test for moving value blocks right/left

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -114,6 +114,9 @@
                 <option value="moveStatementTestBlocks">
                   move statement test blocks
                 </option>
+                <option value="moveValueTestBlocks">
+                  move value test blocks
+                </option>
                 <option value="comments">comments</option>
               </select>
             </div>

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -1000,10 +1000,19 @@ const moveValueTestBlocks = {
         },
       },
       {
+        'type': 'text',
+        'id': 'unattached',
+        'x': 75,
+        'y': 200,
+        'fields': {
+          'TEXT': 'unattached value',
+        },
+      },
+      {
         'type': 'p5_draw',
         'id': 'p5_draw',
         'x': 75,
-        'y': 200,
+        'y': 260,
         'deletable': false,
         'inputs': {
           'STATEMENTS': {
@@ -1013,10 +1022,21 @@ const moveValueTestBlocks = {
               'inputs': {
                 'TEXT': {
                   'block': {
-                    'type': 'text',
-                    'id': 'simple_mover',
+                    'type': 'text_changeCase',
+                    'id': 'complex_mover',
                     'fields': {
-                      'TEXT': 'simple mover',
+                      'CASE': 'TITLECASE',
+                    },
+                    'inputs': {
+                      'TEXT': {
+                        'block': {
+                          'type': 'text',
+                          'id': 'simple_mover',
+                          'fields': {
+                            'TEXT': 'simple mover',
+                          },
+                        },
+                      },
                     },
                   },
                 },

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -1054,15 +1054,16 @@ const moveValueTestBlocks = {
                               'inputs': {
                                 'TEXT': {
                                   'block': {
-                                    'type': 'text_count',
-                                    'id': 'text_count1',
+                                    'type': 'text_join',
+                                    'id': 'text_join1',
+                                    'inline': true,
                                     'inputs': {
-                                      'SUB': {
+                                      'ADD0': {
                                         'shadow': {
                                           'type': 'text',
-                                          'id': 'shadow_count1.1',
+                                          'id': 'shadow_join',
                                           'fields': {
-                                            'TEXT': 'shadow',
+                                            'TEXT': 'inline',
                                           },
                                         },
                                       },
@@ -1091,8 +1092,8 @@ const moveValueTestBlocks = {
                                         'inputs': {
                                           'TEXT': {
                                             'block': {
-                                              'type': 'text_count',
-                                              'id': 'text_count2',
+                                              'type': 'text_join',
+                                              'id': 'text_join2',
                                               'inline': false,
                                             },
                                           },

--- a/test/loadTestBlocks.js
+++ b/test/loadTestBlocks.js
@@ -974,6 +974,150 @@ const moveStatementTestBlocks = {
   },
 };
 
+const moveValueTestBlocks = {
+  'blocks': {
+    'languageVersion': 0,
+    'blocks': [
+      {
+        'type': 'p5_setup',
+        'id': 'p5_setup',
+        'x': 75,
+        'y': 75,
+        'deletable': false,
+        'inputs': {
+          'STATEMENTS': {
+            'block': {
+              'type': 'p5_canvas',
+              'id': 'p5_canvas',
+              'deletable': false,
+              'movable': false,
+              'fields': {
+                'WIDTH': 400,
+                'HEIGHT': 400,
+              },
+            },
+          },
+        },
+      },
+      {
+        'type': 'p5_draw',
+        'id': 'p5_draw',
+        'x': 75,
+        'y': 200,
+        'deletable': false,
+        'inputs': {
+          'STATEMENTS': {
+            'block': {
+              'type': 'text_print',
+              'id': 'print0',
+              'inputs': {
+                'TEXT': {
+                  'block': {
+                    'type': 'text',
+                    'id': 'simple_mover',
+                    'fields': {
+                      'TEXT': 'simple mover',
+                    },
+                  },
+                },
+              },
+              'next': {
+                'block': {
+                  'type': 'text_print',
+                  'id': 'print1',
+                  'next': {
+                    'block': {
+                      'type': 'text_print',
+                      'id': 'print2',
+                      'inputs': {
+                        'TEXT': {
+                          'shadow': {
+                            'type': 'text',
+                            'id': 'shadow_print2',
+                            'fields': {
+                              'TEXT': 'shadow',
+                            },
+                          },
+                        },
+                      },
+                      'next': {
+                        'block': {
+                          'type': 'draw_emoji',
+                          'id': 'draw_emoji',
+                          'fields': {
+                            'emoji': '🐻',
+                          },
+                          'next': {
+                            'block': {
+                              'type': 'text_print',
+                              'id': 'print3',
+                              'inputs': {
+                                'TEXT': {
+                                  'block': {
+                                    'type': 'text_count',
+                                    'id': 'text_count1',
+                                    'inputs': {
+                                      'SUB': {
+                                        'shadow': {
+                                          'type': 'text',
+                                          'id': 'shadow_count1.1',
+                                          'fields': {
+                                            'TEXT': 'shadow',
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                              'next': {
+                                'block': {
+                                  'type': 'controls_repeat_ext',
+                                  'id': 'controls_repeat_ext',
+                                  'inputs': {
+                                    'TIMES': {
+                                      'shadow': {
+                                        'type': 'math_number',
+                                        'id': 'shadow_repeat',
+                                        'fields': {
+                                          'NUM': 1,
+                                        },
+                                      },
+                                    },
+                                    'DO': {
+                                      'block': {
+                                        'type': 'text_print',
+                                        'id': 'print4',
+                                        'inputs': {
+                                          'TEXT': {
+                                            'block': {
+                                              'type': 'text_count',
+                                              'id': 'text_count2',
+                                              'inline': false,
+                                            },
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+};
+
 const comments = {
   'workspaceComments': [
     {
@@ -1101,6 +1245,7 @@ export const load = function (workspace, scenarioString) {
     moreBlocks,
     moveStartTestBlocks,
     moveStatementTestBlocks,
+    moveValueTestBlocks,
     navigationTestBlocks,
     simpleCircle,
     'sun': sunnyDay,

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -368,6 +368,25 @@ suite(`Value expression move tests`, function () {
     EXPECTED_SIMPLE_RIGHT.slice(1).reverse(),
   );
 
+  /** ID of a unary expression block (block with one value input + output) */
+  const BLOCK_COMPLEX = 'complex_mover';
+
+  /**
+   * Expected connection candidates when moving row consisting of
+   * BLOCK_COMPLEX, with a block (in this case BLOCK_SIMPLE) attached
+   * to its input, after pressing ArrowRight n times.
+   */
+  const EXPECTED_ROW_RIGHT = EXPECTED_SIMPLE_RIGHT.slice();
+  EXPECTED_ROW_RIGHT[0] = EXPECTED_ROW_RIGHT.pop()!;
+  /**
+   * Expected connection candidates when moving row consisting of
+   * BLOCK_COMPLEX, with a block (in this case BLOCK_SIMPLE) attached
+   * to its input, after pressing ArrowLeft n times.
+   */
+  const EXPECTED_ROW_LEFT = EXPECTED_ROW_RIGHT.slice(0, 1).concat(
+    EXPECTED_ROW_RIGHT.slice(1).reverse(),
+  );
+
   for (const renderer of ['geras', 'thrasos', 'zelos']) {
     suite(`using ${renderer}`, function () {
       // Clear the workspace and load start blocks.
@@ -388,6 +407,16 @@ suite(`Value expression move tests`, function () {
         test(
           'moving left',
           moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_LEFT),
+        );
+      });
+      suite('Constrained moves of two blocks with no free inputs', function () {
+        test(
+          'moving right',
+          moveTest(BLOCK_COMPLEX, Key.ArrowRight, EXPECTED_ROW_RIGHT),
+        );
+        test(
+          'moving left',
+          moveTest(BLOCK_COMPLEX, Key.ArrowLeft, EXPECTED_ROW_LEFT),
         );
       });
     });

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -329,61 +329,66 @@ suite('Statement move tests', function () {
   });
 });
 
-for (const renderer of ['geras', 'zelos']) {
-  suite(`Value expression move tests (${renderer})`, function () {
-    // Increase timeout to 10s for this longer test (but disable
-    // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
-    this.timeout(PAUSE_TIME ? 0 : 10000);
+suite(`Value expression move tests`, function () {
+  // Increase timeout to 10s for this longer test (but disable
+  // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
+  this.timeout(PAUSE_TIME ? 0 : 10000);
 
-    // Clear the workspace and load start blocks.
-    setup(async function () {
-      this.browser = await testSetup(
-        createTestUrl(
-          new URLSearchParams({renderer, scenario: 'moveValueTestBlocks'}),
-        ),
+  /** ID of a simple reporter (a value block with no inputs). */
+  const BLOCK_SIMPLE = 'simple_mover';
+
+  /**
+   * Expected connection candidates when moving BLOCK_SIMPLE, after
+   * pressing ArrowRight n times.
+   */
+  const EXPECTED_SIMPLE_RIGHT = [
+    {id: 'print0', index: 2, ownIndex: 0}, // Starting location.
+    {id: 'print1', index: 2, ownIndex: 0}, // Print block with no shadow.
+    {id: 'print2', index: 2, ownIndex: 0}, // Print block with shadow.
+    // Skip draw_emoji block as it has no value inputs.
+    {id: 'print3', index: 2, ownIndex: 0}, // Replacing  join expression.
+    {id: 'text_join1', index: 1, ownIndex: 0}, // Join block ADD0 input.
+    {id: 'text_join1', index: 2, ownIndex: 0}, // Join block ADD1 input.
+    // Skip controls_repeat_ext block's TIMES input as it is incompatible.
+    {id: 'print4', index: 2, ownIndex: 0}, // Replacing join expression.
+    {id: 'text_join2', index: 1, ownIndex: 0}, // Join block ADD0 input.
+    {id: 'text_join2', index: 2, ownIndex: 0}, // Join block ADD1 input.
+  ];
+  /**
+   * Expected connection candidates when moving BLOCK_SIMPLE, after
+   * pressing ArrowLeft n times.
+   */
+  const EXPECTED_SIMPLE_LEFT = EXPECTED_SIMPLE_RIGHT.slice(0, 1).concat(
+    EXPECTED_SIMPLE_RIGHT.slice(1).reverse(),
+  );
+
+  for (const renderer of ['geras', 'thrasos', 'zelos']) {
+    // TODO(#707): These tests fail when run using zelos, so for now
+    // we skip entire suite.  Stop skipping suite when bug is fixed.
+    // const suiteOrSkip = renderer === 'zelos' ? suite.skip : suite;
+    // suiteOrSkip(`using ${renderer}`, function () {
+    suite(`using ${renderer}`, function () {
+      // Clear the workspace and load start blocks.
+      setup(async function () {
+        this.browser = await testSetup(
+          createTestUrl(
+            new URLSearchParams({renderer, scenario: 'moveValueTestBlocks'}),
+          ),
+        );
+        await this.browser.pause(PAUSE_TIME);
+      });
+
+      test(
+        'Constrained move of simple value block right',
+        moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE_RIGHT),
       );
-      await this.browser.pause(PAUSE_TIME);
+      test(
+        'Constrained move of simple value block left',
+        moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_LEFT),
+      );
     });
-
-    /** ID of a simple reporter (a value block with no inputs). */
-    const BLOCK_SIMPLE = 'simple_mover';
-
-    /**
-     * Expected connection candidates when moving BLOCK_SIMPLE, after
-     * pressing ArrowRight n times.
-     */
-    const EXPECTED_SIMPLE_RIGHT = [
-      {id: 'print0', index: 2, ownIndex: 0}, // Starting location.
-      {id: 'print1', index: 2, ownIndex: 0}, // Print block with no shadow.
-      {id: 'print2', index: 2, ownIndex: 0}, // Print block with shadow.
-      // Skip draw_emoji block as it has no value inputs.
-      {id: 'print3', index: 2, ownIndex: 0}, // Replacing count expression.
-      {id: 'text_count1', index: 1, ownIndex: 0}, // Count block SUB input.
-      {id: 'text_count1', index: 2, ownIndex: 0}, // Count block TEXT input.
-      // Skip controls_repeat_ext block's TIMES input as it is incompatible.
-      {id: 'print4', index: 2, ownIndex: 0}, // Replacing count expression.
-      {id: 'text_count2', index: 1, ownIndex: 0}, // Count block SUB input.
-      {id: 'text_count2', index: 2, ownIndex: 0}, // Count block TEXT input.
-    ];
-    /**
-     * Expected connection candidates when moving BLOCK_SIMPLE, after
-     * pressing ArrowLeft n times.
-     */
-    const EXPECTED_SIMPLE_LEFT = EXPECTED_SIMPLE_RIGHT.slice(0, 1).concat(
-      EXPECTED_SIMPLE_RIGHT.slice(1).reverse(),
-    );
-
-    const testOrSkip = renderer === 'zelos' ? test.skip : test;
-    testOrSkip(
-      'Constrained move of simple value block right',
-      moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE_RIGHT),
-    );
-    testOrSkip(
-      'Constrained move of simple value block left',
-      moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_LEFT),
-    );
-  });
-}
+  }
+});
 
 /**
  * Create a mocha test function moving a specified block in a

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -179,9 +179,9 @@ suite('Statement move tests', function () {
 
   /**
    * Expected connection candidates when moving BLOCK_SIMPLE, after
-   * pressing right or down arrow n times.
+   * pressing right (or down) arrow n times.
    */
-  const EXPECTED_SIMPLE = [
+  const EXPECTED_SIMPLE_RIGHT = [
     {id: 'p5_canvas', index: 1, ownIndex: 0}, // Next; starting location.
     {id: 'complex_mover', index: 3, ownIndex: 0}, // "If" statement input.
     {id: 'complex_mover', index: 4, ownIndex: 0}, // "Else" statement input.
@@ -198,37 +198,39 @@ suite('Statement move tests', function () {
   ];
   /**
    * Expected connection candidates when moving BLOCK_SIMPLE after
-   * pressing left or up arrow n times.
+   * pressing left (or up) arrow n times.
    */
-  const EXPECTED_SIMPLE_REVERSED = EXPECTED_SIMPLE.slice(0, 1).concat(
-    EXPECTED_SIMPLE.slice(1).reverse(),
+  const EXPECTED_SIMPLE_LEFT = EXPECTED_SIMPLE_RIGHT.slice(0, 1).concat(
+    EXPECTED_SIMPLE_RIGHT.slice(1).reverse(),
   );
 
-  test(
-    'Constrained move of simple stack block right',
-    moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE),
-  );
-  test(
-    'Constrained move of simple stack block left',
-    moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_REVERSED),
-  );
-  test(
-    'Constrained move of simple stack block down',
-    moveTest(BLOCK_SIMPLE, Key.ArrowDown, EXPECTED_SIMPLE),
-  );
-  test(
-    'Constrained move of simple stack block up',
-    moveTest(BLOCK_SIMPLE, Key.ArrowUp, EXPECTED_SIMPLE_REVERSED),
-  );
+  suite('Constrained moves of simple stack block', function () {
+    test(
+      'moving right',
+      moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE_RIGHT),
+    );
+    test(
+      'moving left',
+      moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_LEFT),
+    );
+    test(
+      'moving down',
+      moveTest(BLOCK_SIMPLE, Key.ArrowDown, EXPECTED_SIMPLE_RIGHT),
+    );
+    test(
+      'moving up',
+      moveTest(BLOCK_SIMPLE, Key.ArrowUp, EXPECTED_SIMPLE_LEFT),
+    );
+  });
 
   /** ID of a statement block with multiple statement inputs. */
   const BLOCK_COMPLEX = 'complex_mover';
 
   /**
    * Expected connection candidates when moving BLOCK_COMPLEX, after
-   * pressing right or down arrow n times.
+   * pressing right (or down) arrow n times.
    */
-  const EXPECTED_COMPLEX = [
+  const EXPECTED_COMPLEX_RIGHT = [
     // TODO(#702): Due to a bug in KeyboardDragStrategy, certain
     // connection candidates that can be found using the mouse are not
     // visited when doing a keyboard drag.  They appear in the list
@@ -252,26 +254,28 @@ suite('Statement move tests', function () {
    * Expected connection candidates when moving BLOCK_COMPLEX after
    * pressing left or up arrow n times.
    */
-  const EXPECTED_COMPLEX_REVERSED = EXPECTED_COMPLEX.slice(0, 1).concat(
-    EXPECTED_COMPLEX.slice(1).reverse(),
+  const EXPECTED_COMPLEX_LEFT = EXPECTED_COMPLEX_RIGHT.slice(0, 1).concat(
+    EXPECTED_COMPLEX_RIGHT.slice(1).reverse(),
   );
 
-  test(
-    'Constrained move of complex stack block right',
-    moveTest(BLOCK_COMPLEX, Key.ArrowRight, EXPECTED_COMPLEX),
-  );
-  test(
-    'Constrained move of complex stack block left',
-    moveTest(BLOCK_COMPLEX, Key.ArrowLeft, EXPECTED_COMPLEX_REVERSED),
-  );
-  test(
-    'Constrained move of complex stack block down',
-    moveTest(BLOCK_COMPLEX, Key.ArrowDown, EXPECTED_COMPLEX),
-  );
-  test(
-    'Constrained move of complex stack block up',
-    moveTest(BLOCK_COMPLEX, Key.ArrowUp, EXPECTED_COMPLEX_REVERSED),
-  );
+  suite('Constrained moves of stack block with statement inputs', function () {
+    test(
+      'moving right',
+      moveTest(BLOCK_COMPLEX, Key.ArrowRight, EXPECTED_COMPLEX_RIGHT),
+    );
+    test(
+      'moving left',
+      moveTest(BLOCK_COMPLEX, Key.ArrowLeft, EXPECTED_COMPLEX_LEFT),
+    );
+    test(
+      'moving down',
+      moveTest(BLOCK_COMPLEX, Key.ArrowDown, EXPECTED_COMPLEX_RIGHT),
+    );
+    test(
+      'moving up',
+      moveTest(BLOCK_COMPLEX, Key.ArrowUp, EXPECTED_COMPLEX_LEFT),
+    );
+  });
 
   // When a top-level block with no previous, next or output
   // connections is subject to a constrained move, it should not move.
@@ -365,10 +369,6 @@ suite(`Value expression move tests`, function () {
   );
 
   for (const renderer of ['geras', 'thrasos', 'zelos']) {
-    // TODO(#707): These tests fail when run using zelos, so for now
-    // we skip entire suite.  Stop skipping suite when bug is fixed.
-    // const suiteOrSkip = renderer === 'zelos' ? suite.skip : suite;
-    // suiteOrSkip(`using ${renderer}`, function () {
     suite(`using ${renderer}`, function () {
       // Clear the workspace and load start blocks.
       setup(async function () {
@@ -380,14 +380,16 @@ suite(`Value expression move tests`, function () {
         await this.browser.pause(PAUSE_TIME);
       });
 
-      test(
-        'Constrained move of simple value block right',
-        moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE_RIGHT),
-      );
-      test(
-        'Constrained move of simple value block left',
-        moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_LEFT),
-      );
+      suite('Constrained moves of a simple reporter block', function () {
+        test(
+          'moving right',
+          moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE_RIGHT),
+        );
+        test(
+          'moving left',
+          moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_LEFT),
+        );
+      });
     });
   }
 });

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -10,6 +10,7 @@ import {Browser, Key} from 'webdriverio';
 import {
   PAUSE_TIME,
   focusOnBlock,
+  createTestUrl,
   testFileLocations,
   testSetup,
   sendKeyAndWait,
@@ -327,6 +328,25 @@ suite('Statement move tests', function () {
     await sendKeyAndWait(this.browser, Key.Escape);
   });
 });
+
+for (const renderer of ['geras', 'zelos']) {
+  suite(`Value expression move tests (${renderer})`, function () {
+    // Increase timeout to 10s for this longer test (but disable
+    // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
+    this.timeout(PAUSE_TIME ? 0 : 10000);
+
+    // Clear the workspace and load start blocks.
+    setup(async function () {
+      this.browser = await testSetup(
+        createTestUrl(
+          new URLSearchParams({renderer, scenario: 'moveValueTestBlocks'}),
+        ),
+      );
+      await this.browser.pause(PAUSE_TIME);
+    });
+
+  });
+}
 
 /**
  * Create a mocha test function moving a specified block in a

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -345,6 +345,43 @@ for (const renderer of ['geras', 'zelos']) {
       await this.browser.pause(PAUSE_TIME);
     });
 
+    /** ID of a simple reporter (a value block with no inputs). */
+    const BLOCK_SIMPLE = 'simple_mover';
+
+    /**
+     * Expected connection candidates when moving BLOCK_SIMPLE, after
+     * pressing ArrowRight n times.
+     */
+    const EXPECTED_SIMPLE_RIGHT = [
+      {id: 'print0', index: 2, ownIndex: 0}, // Starting location.
+      {id: 'print1', index: 2, ownIndex: 0}, // Print block with no shadow.
+      {id: 'print2', index: 2, ownIndex: 0}, // Print block with shadow.
+      // Skip draw_emoji block as it has no value inputs.
+      {id: 'print3', index: 2, ownIndex: 0}, // Replacing count expression.
+      {id: 'text_count1', index: 1, ownIndex: 0}, // Count block SUB input.
+      {id: 'text_count1', index: 2, ownIndex: 0}, // Count block TEXT input.
+      // Skip controls_repeat_ext block's TIMES input as it is incompatible.
+      {id: 'print4', index: 2, ownIndex: 0}, // Replacing count expression.
+      {id: 'text_count2', index: 1, ownIndex: 0}, // Count block SUB input.
+      {id: 'text_count2', index: 2, ownIndex: 0}, // Count block TEXT input.
+    ];
+    /**
+     * Expected connection candidates when moving BLOCK_SIMPLE, after
+     * pressing ArrowLeft n times.
+     */
+    const EXPECTED_SIMPLE_LEFT = EXPECTED_SIMPLE_RIGHT.slice(0, 1).concat(
+      EXPECTED_SIMPLE_RIGHT.slice(1).reverse(),
+    );
+
+    const testOrSkip = renderer === 'zelos' ? test.skip : test;
+    testOrSkip(
+      'Constrained move of simple value block right',
+      moveTest(BLOCK_SIMPLE, Key.ArrowRight, EXPECTED_SIMPLE_RIGHT),
+    );
+    testOrSkip(
+      'Constrained move of simple value block left',
+      moveTest(BLOCK_SIMPLE, Key.ArrowLeft, EXPECTED_SIMPLE_LEFT),
+    );
   });
 }
 

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -455,7 +455,8 @@ suite(`Value expression move tests`, function () {
           await sendKeyAndWait(this.browser, Key.Delete);
         });
 
-        test(
+        // TODO(#709): Reenable test once crash bug is fixed.
+        test.skip(
           'moving right',
           moveTest(BLOCK_COMPLEX, Key.ArrowRight, EXPECTED_UNARY_RIGHT),
         );

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -377,6 +377,7 @@ suite(`Value expression move tests`, function () {
    * to its input, after pressing ArrowRight n times.
    */
   const EXPECTED_ROW_RIGHT = EXPECTED_SIMPLE_RIGHT.slice();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   EXPECTED_ROW_RIGHT[0] = EXPECTED_ROW_RIGHT.pop()!;
   /**
    * Expected connection candidates when moving row consisting of

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -342,7 +342,7 @@ suite(`Value expression move tests`, function () {
    * pressing ArrowRight n times.
    */
   const EXPECTED_SIMPLE_RIGHT = [
-    {id: 'print0', index: 2, ownIndex: 0}, // Starting location.
+    {id: 'complex_mover', index: 1, ownIndex: 0}, // Starting location.
     {id: 'print1', index: 2, ownIndex: 0}, // Print block with no shadow.
     {id: 'print2', index: 2, ownIndex: 0}, // Print block with shadow.
     // Skip draw_emoji block as it has no value inputs.
@@ -353,6 +353,8 @@ suite(`Value expression move tests`, function () {
     {id: 'print4', index: 2, ownIndex: 0}, // Replacing join expression.
     {id: 'text_join2', index: 1, ownIndex: 0}, // Join block ADD0 input.
     {id: 'text_join2', index: 2, ownIndex: 0}, // Join block ADD1 input.
+    // Skip unconnected text block as it has no inputs.
+    {id: 'print0', index: 2, ownIndex: 0}, // Print block having complex_mover.
   ];
   /**
    * Expected connection candidates when moving BLOCK_SIMPLE, after

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -414,7 +414,10 @@ suite(`Value expression move tests`, function () {
   );
 
   for (const renderer of ['geras', 'thrasos', 'zelos']) {
-    suite(`using ${renderer}`, function () {
+    // TODO(#707): These tests fail when run using zelos, so for now
+    // we skip entire suite.  Stop skipping suite when bug is fixed.
+    const suiteOrSkip = renderer === 'zelos' ? suite.skip : suite;
+    suiteOrSkip(`using ${renderer}`, function () {
       // Clear the workspace and load start blocks.
       setup(async function () {
         this.browser = await testSetup(

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -387,6 +387,32 @@ suite(`Value expression move tests`, function () {
     EXPECTED_ROW_RIGHT.slice(1).reverse(),
   );
 
+  /**
+   * Expected connection candidates when moving row consisting of
+   * BLOCK_COMPLEX on its own after pressing ArrowRight n times.
+   */
+  const EXPECTED_UNARY_RIGHT = [
+    {id: 'print0', index: 2, ownIndex: 0}, // Starting location.
+    {id: 'print1', index: 2, ownIndex: 0}, // Print block with no shadow.
+    {id: 'print2', index: 2, ownIndex: 0}, // Print block with shadow.
+    // Skip draw_emoji block as it has no value inputs.
+    {id: 'print3', index: 2, ownIndex: 0}, // Replacing  join expression.
+    {id: 'text_join1', index: 1, ownIndex: 0}, // Join block ADD0 input.
+    {id: 'text_join1', index: 2, ownIndex: 0}, // Join block ADD1 input.
+    // Skip controls_repeat_ext block's TIMES input as it is incompatible.
+    {id: 'print4', index: 2, ownIndex: 0}, // Replacing join expression.
+    {id: 'text_join2', index: 1, ownIndex: 0}, // Join block ADD0 input.
+    {id: 'text_join2', index: 2, ownIndex: 0}, // Join block ADD1 input.
+    {id: 'unattached', index: 0, ownIndex: 1}, // Unattached text to own input.
+  ];
+  /**
+   * Expected connection candidates when moving row consisting of
+   * BLOCK_UNARY on its own after pressing ArrowLEFT n times.
+   */
+  const EXPECTED_UNARY_LEFT = EXPECTED_UNARY_RIGHT.slice(0, 1).concat(
+    EXPECTED_UNARY_RIGHT.slice(1).reverse(),
+  );
+
   for (const renderer of ['geras', 'thrasos', 'zelos']) {
     suite(`using ${renderer}`, function () {
       // Clear the workspace and load start blocks.
@@ -417,6 +443,22 @@ suite(`Value expression move tests`, function () {
         test(
           'moving left',
           moveTest(BLOCK_COMPLEX, Key.ArrowLeft, EXPECTED_ROW_LEFT),
+        );
+      });
+      suite('Constrained moves of unary expression block', function () {
+        setup(async function () {
+          // Delete block connected to complex_mover's input.
+          await focusOnBlock(this.browser, BLOCK_SIMPLE);
+          await sendKeyAndWait(this.browser, Key.Delete);
+        });
+
+        test(
+          'moving right',
+          moveTest(BLOCK_COMPLEX, Key.ArrowRight, EXPECTED_UNARY_RIGHT),
+        );
+        test(
+          'moving left',
+          moveTest(BLOCK_COMPLEX, Key.ArrowLeft, EXPECTED_UNARY_LEFT),
         );
       });
     });

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -131,9 +131,7 @@ export async function testSetup(
  * @returns posix path
  */
 function posixPath(target: string): string {
-  const result = target.split(path.sep).join(path.posix.sep);
-  console.log(result);
-  return result;
+  return target.split(path.sep).join(path.posix.sep);
 }
 
 // Relative to dist folder for TS build

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -558,6 +558,7 @@ export async function sendKeyAndWait(
   keys: string | string[],
   times = 1,
 ) {
+  // @ts-ignore: Unintentional comparison error
   if (PAUSE_TIME === 0) {
     // Send all keys in one call if no pauses needed.
     keys = Array(times).fill(keys).flat();

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -558,6 +558,7 @@ export async function sendKeyAndWait(
   keys: string | string[],
   times = 1,
 ) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore: Unintentional comparison error
   if (PAUSE_TIME === 0) {
     // Send all keys in one call if no pauses needed.

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -137,7 +137,7 @@ function posixPath(target: string): string {
 }
 
 // Relative to dist folder for TS build
-const createTestUrl = (options?: URLSearchParams) => {
+export const createTestUrl = (options?: URLSearchParams) => {
   const dirname = path.dirname(fileURLToPath(import.meta.url));
   const base = new URL(
     `file://${posixPath(path.join(dirname, '..', '..', 'build', 'index.html'))}`,


### PR DESCRIPTION
More work on move tests, including some tweaks to the stack block move test code added by PR #704:

* Add a `// @ts-ignore` to suppress an Unintended Comparison error that can occur when `PAUSE_TIME` is set to a value other than `0`—and then add an `// eslint-disable-next-line` to suppress a lint error caused by use of `@ts-ignore`.
* Modify the `moveTest` helper: by assuming that the moving block always finishes at the same location it starts, it's possible to considerably simplify the tests that call it.
  * Tests to verify correct reconnection after end of move (e.g. healing) will be done in a separate suite as part of #699.

as well as new work:

* Create `moveValueTestBlocks`, a set of test blocks for testing correct behaviour of constrained moves of value blocks.
* Add tests for moving the following things right and left:
  1. A simple reporter block (value block with one field and no inputs—in this case a `text` block).
  2. A unary expression: a value block with one input and one output.
  3. A two-block row, formed by connecting 1 to 2.
* Refactor both existing stack block and new value block move tests to make better use of nested suites.
  * For the value block tests, add an additional layer of nested suites so that these tests will be run in each of geras, thrasos and zelos, since some of the move code behaves differently depending on which renderer is used.
* Some code to skip certain tests that fail due to #707 and #709.
* Remove a debugging `console.log` from `test_setup.ts`.

Part of #696.
Supersedes #706.
