### PR TITLE
fix: Don't try to move blocks onto shadow block connections.

### DIFF
--- a/src/keyboard_drag_strategy.ts
+++ b/src/keyboard_drag_strategy.ts
@@ -54,6 +54,7 @@ export class KeyboardDragStrategy extends dragging.BlockDragStrategy {
       this.allConnections.push(
         ...topBlock
           .getDescendants(true)
+          .filter((block: BlockSvg) => !block.isShadow())
           .flatMap((block: BlockSvg) => block.getConnections_(false))
           .sort((a: RenderedConnection, b: RenderedConnection) => {
             let delta = a.y - b.y;


### PR DESCRIPTION
This PR fixes #709 by excluding connections on shadow blocks from the list of connections which blocks in move mode are eligible to visit/connect to. This does not prevent moving a block to overwrite a shadow block, only moving a block to an open connection *on* a shadow block, which seems like a generally unreasonable thing to do.