### PR TITLE
fix: callbackkey for flyoutbuttons not case sensitive

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -332,14 +332,15 @@ export class EnterAction {
       // @ts-expect-error private field access
       workspace.flyoutButtonCallbacks;
 
-    const info = button.info;
-    if ('callbackkey' in info) {
-      const buttonCallback = flyoutButtonCallbacks.get(info.callbackkey);
-      if (!buttonCallback) {
-        throw new Error('No callback function found for flyout button.');
-      }
-      buttonCallback(button);
+    // TODO: Remove cast once blockly 12.4.0 is the minimum version of Blockly required.
+    // button.callbackKey is private until that version.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const callbackKey = (button as any).callbackKey;
+    const buttonCallback = flyoutButtonCallbacks.get(callbackKey);
+    if (!buttonCallback) {
+      throw new Error('No callback function found for flyout button.');
     }
+    buttonCallback(button);
   }
 
   /**

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -6,6 +6,7 @@
 
 import * as chai from 'chai';
 import * as Blockly from 'blockly';
+import * as webdriverio from 'webdriverio';
 import {
   testSetup,
   testFileLocations,
@@ -18,6 +19,7 @@ import {
   keyRight,
   getCurrentFocusNodeId,
   getCurrentFocusedBlockId,
+  tabNavigateToToolbox,
 } from './test_setup.js';
 
 suite('Toolbox and flyout test', function () {
@@ -243,6 +245,77 @@ suite('Toolbox and flyout test', function () {
     const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
     chai.assert.strictEqual(focusedId, elemId);
     chai.assert.isTrue(flyoutIsOpen);
+  });
+
+  suite('Flyout buttons', function () {
+    setup(async function () {
+      // New toolbox definition
+      const toolbox = {
+        'kind': 'categoryToolbox',
+        'contents': [
+          {
+            'kind': 'category',
+            'name': 'test category',
+            'contents': [
+              {
+                'kind': 'button',
+                'text': 'A button',
+                // Note lowercase
+                'callbackkey': 'buttonCallback',
+              },
+              {
+                'kind': 'button',
+                'text': 'Second button',
+                // Note camelCase
+                'callbackKey': 'buttonCallback',
+              },
+            ],
+          },
+        ],
+      };
+
+      // Replace toolbox contents & register button callback
+      await this.browser.execute((toolboxDef) => {
+        const ws = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+        ws.updateToolbox(toolboxDef);
+        ws.registerButtonCallback('buttonCallback', () => {
+          alert('Button pressed');
+        });
+      }, toolbox);
+    });
+    teardown(async function () {
+      try {
+        await this.browser.acceptAlert();
+      } catch {
+        // Don't do anything if the alert isn't present, the test already failed elsewhere.
+      }
+    });
+    test('callbackkey is activated with enter', async function () {
+      await tabNavigateToToolbox(this.browser);
+      await this.browser.pause(PAUSE_TIME);
+
+      // First thing in the toolbox is the first button
+      // Press Enter to activate it.
+      await keyRight(this.browser);
+      await sendKeyAndWait(this.browser, webdriverio.Key.Enter);
+
+      // This errors if there is no alert present
+      await this.browser.getAlertText();
+    });
+
+    test('callbackKey is activated with enter', async function () {
+      await tabNavigateToToolbox(this.browser);
+      await this.browser.pause(PAUSE_TIME);
+
+      // Navigate to second button.
+      // Press Enter to activate it.
+      await keyRight(this.browser);
+      await keyDown(this.browser);
+      await sendKeyAndWait(this.browser, webdriverio.Key.Enter);
+
+      // This errors if there is no alert present
+      await this.browser.getAlertText();
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #727 

- Uses the `callbackKey` property of `button` instead of trying to recalculate it incorrectly.
- I've already merged a PR in core that makes that property public, until then we suppress the error. Note that I can't use // ts-expect-error here because I *don't* expect an error on Blockly v12.4 (which doesn't exist yet, but will eventually) and I don't want to bump the minimum version of blockly just to remove that comment. This method works for versions before and after that.
- Adds a test to make sure both toolbox definitions are working.
