### PR TITLE
fix: CI tests on OS X

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
   build_tip_of_tree_v12:
     name: Build test (against tip-of-tree core develop)
     runs-on: ubuntu-latest
+    if: false
     steps:
       - name: Checkout experimentation plugin
         uses: actions/checkout@v4
@@ -59,8 +60,7 @@ jobs:
 
   build:
     name: Build test (against pinned v12)
-    # Don't run pinned version checks for PRs.
-    if: ${{ !github.base_ref }}
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout experimentation plugin
@@ -81,6 +81,7 @@ jobs:
     name: Eslint check
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    if: false
     steps:
       - uses: actions/checkout@v4
 
@@ -99,6 +100,7 @@ jobs:
     name: Prettier check
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    if: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
   build_tip_of_tree_v12:
     name: Build test (against tip-of-tree core develop)
     runs-on: ubuntu-latest
-    if: false
     steps:
       - name: Checkout experimentation plugin
         uses: actions/checkout@v4
@@ -60,7 +59,8 @@ jobs:
 
   build:
     name: Build test (against pinned v12)
-    if: false
+    # Don't run pinned version checks for PRs.
+    if: ${{ !github.base_ref }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout experimentation plugin
@@ -81,7 +81,6 @@ jobs:
     name: Eslint check
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    if: false
     steps:
       - uses: actions/checkout@v4
 
@@ -100,7 +99,6 @@ jobs:
     name: Prettier check
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    if: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout experimentation plugin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
 
     steps:
       - name: Checkout experimentation plugin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,11 +69,18 @@ jobs:
       - name: Run tests (up to 50 times)
         run: |
           cd main/test/webdriverio/test
-          for i in $(seq 1 50);
-          do
+          #for i in $(seq 1 50);
+          #do
             echo "Attempt $i"
             npx mocha --timeout 30000 dist
-          done
+          #done
+
+      - name: Upload test failure screenshots
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-failure-screenshots
+          path: test/webdriverio/test/failures
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v5
         with:
-          name: test-failure-screenshots
+          name: test-failure-screenshots-${{ matrix.os }}
           path: main/test/webdriverio/test/failures
 
   webdriverio_tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   webdriverio_tests_tip_of_tree_v12:
     name: WebdriverIO tests (against tip-of-tree core develop)
-    timeout-minutes: 10
+    # timeout-minutes: 10
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -60,13 +60,19 @@ jobs:
           npm link blockly
           cd ..
 
-      - name: Run tests
+      - name: Build tests
         run: |
           cd main
+          npm run wdio:clean
+          npm run wdio:build
+
+      - name: Run tests (up to 50 times)
+        run: |
+          cd test/webdriverio/test
           for i in $(seq 1 50);
           do
             echo "Attempt $i"
-            npm run test:ci
+            npx mocha --timeout 30000 dist
           done
 
   webdriverio_tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Run tests (up to 50 times)
         run: |
           cd main
-          #for i in $(seq 1 50);
-          #do
+          for i in $(seq 1 50);
+          do
             echo "Attempt $i"
             npm run wdio:run:ci
-          #done
+          done
 
       - name: Upload test failure screenshots
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
 
     steps:
       - name: Checkout experimentation plugin
@@ -67,8 +67,7 @@ jobs:
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)
-    # Don't run pinned version checks for PRs.
-    if: ${{ !github.base_ref }}
+    if: false
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: test-failure-screenshots
-          path: test/webdriverio/test/failures
+          path: main/test/webdriverio/test/failures
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   webdriverio_tests_tip_of_tree_v12:
     name: WebdriverIO tests (against tip-of-tree core develop)
-    # timeout-minutes: 10
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -60,19 +60,10 @@ jobs:
           npm link blockly
           cd ..
 
-      - name: Build tests
+      - name: Run tests
         run: |
           cd main
-          npm run wdio:clean
-
-      - name: Run tests (up to 50 times)
-        run: |
-          cd main
-          for i in $(seq 1 50);
-          do
-            echo "Attempt $i"
-            npm run wdio:run:ci
-          done
+          npm run test:ci
 
       - name: Upload test failure screenshots
         if: always()
@@ -83,7 +74,8 @@ jobs:
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)
-    if: false
+    # Don't run pinned version checks for PRs.
+    if: ${{ !github.base_ref }}
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run tests (up to 50 times)
         run: |
-          cd test/webdriverio/test
+          cd main/test/webdriverio/test
           for i in $(seq 1 50);
           do
             echo "Attempt $i"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,15 +64,13 @@ jobs:
         run: |
           cd main
           npm run wdio:clean
-          npm run wdio:build
 
       - name: Run tests (up to 50 times)
         run: |
-          cd main/test/webdriverio/test
           #for i in $(seq 1 50);
           #do
             echo "Attempt $i"
-            npx mocha --timeout 30000 dist
+            npm run wdio:run:ci
           #done
 
       - name: Upload test failure screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,11 @@ jobs:
       - name: Run tests
         run: |
           cd main
-          npm run test:ci
+          for i in $(seq 1 50);
+          do
+            echo "Attempt $i"
+            npm run test:ci
+          done
 
   webdriverio_tests:
     name: WebdriverIO tests (against pinned v12)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Run tests (up to 50 times)
         run: |
+          cd main
           #for i in $(seq 1 50);
           #do
             echo "Attempt $i"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'google/blockly'
-          ref: 'develop'
+          ref: 'main'
           path: core-blockly
 
       - name: Use Node.js 20.x

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build-debug.log
 node_modules/
 build/
 dist/
+test/webdriverio/test/failures/

--- a/package-lock.json
+++ b/package-lock.json
@@ -947,6 +947,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1265,6 +1266,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1287,6 +1289,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2084,6 +2087,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2766,6 +2770,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2799,6 +2804,7 @@
       "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -3284,6 +3290,7 @@
       "integrity": "sha512-BbWUcpqroY241XgSxTuAiEMHeIZ6u3+oD2zOATf3Fi+0NMWJ/MdMtuSkOcDCSk6Nc7WR3z5n9GHKqz2L+3kQOQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsdom": "26.1.0"
       },
@@ -3414,6 +3421,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -4852,6 +4860,7 @@
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5665,6 +5674,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5772,6 +5782,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -6870,6 +6895,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9386,6 +9412,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9799,6 +9826,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10098,6 +10126,7 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10439,6 +10468,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
       "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -10486,6 +10516,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -10678,7 +10709,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/webpack-dev-server": {
       "version": "5.2.1",
@@ -10769,6 +10801,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.3.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.5",
-        "webdriverio": "^9.20.1"
+        "webdriverio": "^9.12.1"
       },
       "peerDependencies": {
         "blockly": "^12.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1685,24 +1685,22 @@
           "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
-      "license": "CC-BY-4.0",
       "dependencies": {
         "spacetrim": "0.11.59"
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.13.tgz",
-      "integrity": "sha512-a9Ruw3j3qlnB5a/zHRTkruppynxqaeE4H9WNj5eYGRWqw0ZauZ23f4W2ARf3hghF5doozyD+CRtt7XSYuYRI/Q==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
+      "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.3",
+        "debug": "^4.4.0",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3",
-        "tar-fs": "^3.1.1",
+        "semver": "^7.7.1",
+        "tar-fs": "^3.0.8",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1755,8 +1753,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2026,8 +2023,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
       "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -2044,7 +2040,6 @@
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -2283,15 +2278,14 @@
       "license": "ISC"
     },
     "node_modules/@wdio/config": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.20.1.tgz",
-      "integrity": "sha512-npl2J+rjCDJPjVySgWpciOyhWddn6s7n5sepKXLR7x1ADQHl5zUFv1dHD3jx4OQ9l6lrGQSPaofuz+7e9mu+vg==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.12.1.tgz",
+      "integrity": "sha512-eYyF9HBQg2PyX6ScieZ5akDG4BaJmNBdYFJmwhUAGcJlxLgoI02vSqIuoWaQd5shbvtCdDzsFI0Jt8+S/xqINQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.20.1",
+        "@wdio/logger": "9.4.4",
+        "@wdio/types": "9.10.1",
+        "@wdio/utils": "9.12.1",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0"
@@ -2301,21 +2295,19 @@
       }
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2336,7 +2328,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2348,16 +2339,14 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
-      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.4.4.tgz",
+      "integrity": "sha512-BXx8RXFUW2M4dcO6t5Le95Hi2ZkTQBRsvBQqLekT2rZ6Xmw8ZKZBPf0FptnoftFGg6dYmwnDidYv/0+4PiHjpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
         "loglevel-plugin-prefix": "^0.8.4",
-        "safe-regex2": "^5.0.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
@@ -2365,11 +2354,10 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2378,11 +2366,10 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2391,11 +2378,10 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2407,18 +2393,16 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.16.2.tgz",
-      "integrity": "sha512-h3k97/lzmyw5MowqceAuY3HX/wGJojXHkiPXA3WlhGPCaa2h4+GovV2nJtRvknCKsE7UHA1xB5SWeI8MzloBew==",
-      "dev": true,
-      "license": "MIT"
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.7.0.tgz",
+      "integrity": "sha512-5DI8cqJqT9K6oQn8UpaSTmcGAl4ufkUWC5FoPT3oXdLjILfxvweZDf/2XNBCbGMk4+VOMKqB2ofOqKhDIB2nAg==",
+      "dev": true
     },
     "node_modules/@wdio/repl": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
-      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.4.4.tgz",
+      "integrity": "sha512-kchPRhoG/pCn4KhHGiL/ocNhdpR8OkD2e6sANlSUZ4TGBVi86YSIEjc2yXUwLacHknC/EnQk/SFnqd4MsNjGGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2427,28 +2411,25 @@
       }
     },
     "node_modules/@wdio/repl/node_modules/@types/node": {
-      "version": "20.19.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wdio/repl/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/@wdio/types": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.20.0.tgz",
-      "integrity": "sha512-zMmAtse2UMCSOW76mvK3OejauAdcFGuKopNRH7crI0gwKTZtvV89yXWRziz9cVXpFgfmJCjf9edxKFWdhuF5yw==",
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.10.1.tgz",
+      "integrity": "sha512-/t1VXPU5Ad1FQjRUP0WlK7IR0dCTX5hSkul8SpCuUpWbeyI4Iol/Wx2b1YU6nS+Ydh78rJCyHxtV0eE5TM1rbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2457,40 +2438,36 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "20.19.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wdio/types/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/@wdio/utils": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.20.1.tgz",
-      "integrity": "sha512-C/Gsy5NAatsGUF1eT9Ks/ErR52/X4YI7MSm7BtwNOw8v2Ko+SiCA5qXts61J0A7QYwOn4gfXfBZZnzSAng6G/w==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.12.1.tgz",
+      "integrity": "sha512-WrkBdglOwKMpwvCZbOatlLUCghxNWyVfKRDyl92RBX3DuRqqq+uZK8fSHHAJMvXfax5TxcTRzHZUKrQO3ASSXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.20.0",
+        "@wdio/logger": "9.4.4",
+        "@wdio/types": "9.10.1",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
+        "edgedriver": "^6.1.1",
         "geckodriver": "^5.0.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
         "safaridriver": "^1.0.0",
         "split2": "^4.2.0",
         "wait-port": "^1.1.0"
@@ -2500,11 +2477,10 @@
       }
     },
     "node_modules/@wdio/utils/node_modules/decamelize": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
-      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2735,15 +2711,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
-      "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
+      "version": "2.7.57",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+      "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
-        "node": ">=18.0.0"
+        "node": ">=16.5.0"
       }
     },
     "node_modules/abab": {
@@ -3104,7 +3079,6 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -3116,8 +3090,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
+      "dev": true
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3188,18 +3161,15 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz",
-      "integrity": "sha512-zGUCsm3yv/ePt2PHNbVxjjn0nNB1MkIaR4wOCxJ2ig5pCf5cCVAYJXVhQg/3OhhJV6DB1ts7Hv0oUaElc2TPQg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
+      "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
+        "bare-stream": "^2.6.4"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -3214,11 +3184,10 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -3229,18 +3198,16 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -3256,17 +3223,6 @@
         "bare-events": {
           "optional": true
         }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -3294,7 +3250,6 @@
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4261,7 +4216,6 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -4280,11 +4234,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4347,7 +4300,6 @@
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4400,7 +4352,6 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -4609,7 +4560,6 @@
       "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
       "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/which": "^2.0.1",
         "which": "^2.0.2"
@@ -4622,18 +4572,17 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.2.tgz",
-      "integrity": "sha512-UvFqd/IR81iPyWMcxXbUNi+xKWR7JjfoHjfuwjqsj9UHQKn80RpQmS0jf+U25IPi+gKVPcpOSKm0XkqgGMq4zQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.1.tgz",
+      "integrity": "sha512-/dM/PoBf22Xg3yypMWkmRQrBKEnSyNaZ7wHGCT9+qqT14izwtFT+QvdR89rjNkMfXwW+bSFoqOfbcvM+2Cyc7w==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "^9.1.3",
         "@zip.js/zip.js": "^2.7.53",
         "decamelize": "^6.0.0",
         "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^5.0.8",
+        "fast-xml-parser": "^4.5.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2",
@@ -4647,11 +4596,10 @@
       }
     },
     "node_modules/edgedriver/node_modules/decamelize": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
-      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4664,7 +4612,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
@@ -4674,7 +4621,6 @@
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -4739,11 +4685,10 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4884,7 +4829,6 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4906,7 +4850,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -5379,7 +5322,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -5393,6 +5335,21 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5440,9 +5397,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.2.tgz",
-      "integrity": "sha512-n8v8b6p4Z1sMgqRmqLJm3awW4NX7NkaKPfb3uJIBTSH7Pdvufi3PQ3/lJLQrvxcMYl7JI2jnDO90siPEpD8JBA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "dev": true,
       "funding": [
         {
@@ -5450,9 +5407,8 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5496,7 +5452,6 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -5516,7 +5471,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -5773,7 +5727,6 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -5868,7 +5821,6 @@
       "integrity": "sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "^9.1.3",
         "@zip.js/zip.js": "^2.7.53",
@@ -5887,11 +5839,10 @@
       }
     },
     "node_modules/geckodriver/node_modules/decamelize": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
-      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -5904,7 +5855,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
@@ -5914,7 +5864,6 @@
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -5974,7 +5923,6 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
       "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -5996,28 +5944,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -6032,7 +5963,6 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -6323,11 +6253,10 @@
       }
     },
     "node_modules/htmlfy": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
-      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.6.2.tgz",
+      "integrity": "sha512-dWRE+TW3QSB5mXsnYCUPLoPmaCu2O7kp6/3xh5fayiGuaNtRL/64SdjhoTBwJ2XvuSkLoMgQDLunrAqwxJj40Q==",
+      "dev": true
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -6555,11 +6484,10 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6605,14 +6533,23 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
@@ -6937,6 +6874,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
@@ -7255,7 +7198,6 @@
           "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "@promptbook/utils": "0.69.5",
         "type-fest": "4.26.0",
@@ -7267,7 +7209,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
       "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -7361,7 +7302,6 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -7374,8 +7314,7 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/loupe": {
       "version": "3.1.3",
@@ -7556,13 +7495,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mocha": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
@@ -7734,7 +7666,6 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7799,7 +7730,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
       "funding": [
         {
@@ -7811,7 +7741,6 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -7821,7 +7750,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -8042,7 +7970,6 @@
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -8062,7 +7989,6 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -8297,8 +8223,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8480,7 +8405,6 @@
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -8500,7 +8424,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -8509,15 +8432,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8825,16 +8746,6 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true
     },
-    "node_modules/ret": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
-      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8927,7 +8838,6 @@
       "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
       "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -8952,26 +8862,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-regex2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
-      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.5.0"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -9034,11 +8924,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9099,29 +8988,27 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
-      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
+      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "type-fest": "^4.31.0"
+        "type-fest": "^2.12.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=16"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9439,7 +9326,6 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9458,13 +9344,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -9477,7 +9362,6 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9608,8 +9492,7 @@
           "type": "github",
           "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
         }
-      ],
-      "license": "Apache-2.0"
+      ]
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -9673,7 +9556,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
@@ -9788,17 +9670,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -9860,9 +9741,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10255,11 +10136,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
-      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -10341,7 +10221,6 @@
       "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
       "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -10414,7 +10293,6 @@
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
       "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
@@ -10432,7 +10310,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10466,28 +10343,25 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/webdriver": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.20.1.tgz",
-      "integrity": "sha512-QtvYqPai2NOnq7qePPH6kNSwk7+tnmSvnlOnY8dIT/Y24TPdQp44NjF/BUYAWIlqoBlZqHClQFTSVwT2qvO2Tw==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.12.1.tgz",
+      "integrity": "sha512-gtdsfoYAVgPVlN1x3kXhPmOOzQXx6vtw9KB0LCeFQH2zUfNMB7RB1OJN475cFgSgJ7PpyvXk3CKdT1lGCHRTxQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.20.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.16.2",
-        "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.20.1",
+        "@wdio/config": "9.12.1",
+        "@wdio/logger": "9.4.4",
+        "@wdio/protocols": "9.7.0",
+        "@wdio/types": "9.10.1",
+        "@wdio/utils": "9.12.1",
         "deepmerge-ts": "^7.0.3",
-        "https-proxy-agent": "^7.0.6",
-        "undici": "^6.21.3",
+        "undici": "^6.20.1",
         "ws": "^8.8.0"
       },
       "engines": {
@@ -10495,44 +10369,41 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "20.19.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/webdriver/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/webdriverio": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.20.1.tgz",
-      "integrity": "sha512-QVM/asb5sDESz37ow/BAOA0z2HtUJsuAjPKHdw+Vx92PaQP3EfHwTgxK2T5rgwa0WRNh+c+n/0nEqIvqBl01sA==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.12.1.tgz",
+      "integrity": "sha512-xKasUD3DRey9lEcTAbrI29XCxLX45cxVHOIN5EJK44/thch4zhzfskdCKY3BQ9589TCkSGY1CGf8q9LFx2Ve5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.20.1",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.16.2",
-        "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.20.1",
+        "@wdio/config": "9.12.1",
+        "@wdio/logger": "9.4.4",
+        "@wdio/protocols": "9.7.0",
+        "@wdio/repl": "9.4.4",
+        "@wdio/types": "9.10.1",
+        "@wdio/utils": "9.12.1",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
         "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.8.1",
+        "htmlfy": "^0.6.0",
         "is-plain-obj": "^4.1.0",
         "jszip": "^3.10.1",
         "lodash.clonedeep": "^4.5.0",
@@ -10540,15 +10411,15 @@
         "query-selector-shadow-dom": "^1.0.1",
         "resq": "^1.11.0",
         "rgb2hex": "0.2.5",
-        "serialize-error": "^12.0.0",
+        "serialize-error": "^11.0.3",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.20.1"
+        "webdriver": "9.12.1"
       },
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "puppeteer-core": ">=22.x || <=24.x"
+        "puppeteer-core": "^22.3.0"
       },
       "peerDependenciesMeta": {
         "puppeteer-core": {
@@ -11234,7 +11105,6 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -11245,7 +11115,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.3.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.5",
-        "webdriverio": "^9.12.1"
+        "webdriverio": "^9.13.0"
       },
       "peerDependencies": {
         "blockly": "^12.3.0"
@@ -1685,22 +1685,24 @@
           "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
+      "license": "CC-BY-4.0",
       "dependencies": {
         "spacetrim": "0.11.59"
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
-      "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
+      "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.1",
-        "tar-fs": "^3.0.8",
+        "semver": "^7.7.3",
+        "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1753,7 +1755,8 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2023,7 +2026,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
       "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -2040,6 +2044,7 @@
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -2278,14 +2283,15 @@
       "license": "ISC"
     },
     "node_modules/@wdio/config": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.12.1.tgz",
-      "integrity": "sha512-eYyF9HBQg2PyX6ScieZ5akDG4BaJmNBdYFJmwhUAGcJlxLgoI02vSqIuoWaQd5shbvtCdDzsFI0Jt8+S/xqINQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.21.0.tgz",
+      "integrity": "sha512-8TP5/q+Agjc43LET1f0LhLmuEI803O3QtZEbSxOkkvJ7/e1jDWPm4qsL7SjQJlx8xGrW0kwRlPl7+U9Sr0dhCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.10.1",
-        "@wdio/utils": "9.12.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.20.0",
+        "@wdio/utils": "9.21.0",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0"
@@ -2295,19 +2301,21 @@
       }
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2328,6 +2336,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2339,14 +2348,16 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.4.4.tgz",
-      "integrity": "sha512-BXx8RXFUW2M4dcO6t5Le95Hi2ZkTQBRsvBQqLekT2rZ6Xmw8ZKZBPf0FptnoftFGg6dYmwnDidYv/0+4PiHjpQ==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
         "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
@@ -2354,10 +2365,11 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2366,10 +2378,11 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2378,10 +2391,11 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2393,16 +2407,18 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.7.0.tgz",
-      "integrity": "sha512-5DI8cqJqT9K6oQn8UpaSTmcGAl4ufkUWC5FoPT3oXdLjILfxvweZDf/2XNBCbGMk4+VOMKqB2ofOqKhDIB2nAg==",
-      "dev": true
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.16.2.tgz",
+      "integrity": "sha512-h3k97/lzmyw5MowqceAuY3HX/wGJojXHkiPXA3WlhGPCaa2h4+GovV2nJtRvknCKsE7UHA1xB5SWeI8MzloBew==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/repl": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.4.4.tgz",
-      "integrity": "sha512-kchPRhoG/pCn4KhHGiL/ocNhdpR8OkD2e6sANlSUZ4TGBVi86YSIEjc2yXUwLacHknC/EnQk/SFnqd4MsNjGGg==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
+      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2411,25 +2427,28 @@
       }
     },
     "node_modules/@wdio/repl/node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@wdio/repl/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/types": {
-      "version": "9.10.1",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.10.1.tgz",
-      "integrity": "sha512-/t1VXPU5Ad1FQjRUP0WlK7IR0dCTX5hSkul8SpCuUpWbeyI4Iol/Wx2b1YU6nS+Ydh78rJCyHxtV0eE5TM1rbw==",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.20.0.tgz",
+      "integrity": "sha512-zMmAtse2UMCSOW76mvK3OejauAdcFGuKopNRH7crI0gwKTZtvV89yXWRziz9cVXpFgfmJCjf9edxKFWdhuF5yw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2438,36 +2457,40 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@wdio/types/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/utils": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.12.1.tgz",
-      "integrity": "sha512-WrkBdglOwKMpwvCZbOatlLUCghxNWyVfKRDyl92RBX3DuRqqq+uZK8fSHHAJMvXfax5TxcTRzHZUKrQO3ASSXw==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.21.0.tgz",
+      "integrity": "sha512-aj8ao2V/e6Sv9gZby2ZIj4dMLjwYVba47Nlr+pOfK8N4VKKU0VRLPzvTlfK1HWaoS6u/GBbVx2pefYRrvd72BQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.10.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.20.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.1",
-        "geckodriver": "^5.0.0",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
         "safaridriver": "^1.0.0",
         "split2": "^4.2.0",
         "wait-port": "^1.1.0"
@@ -2477,10 +2500,11 @@
       }
     },
     "node_modules/@wdio/utils/node_modules/decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2711,14 +2735,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.57",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
-      "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
+      "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
-        "node": ">=16.5.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/abab": {
@@ -3079,6 +3104,7 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -3090,7 +3116,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3161,15 +3188,18 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
-      "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -3184,10 +3214,11 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
-      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -3198,16 +3229,18 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
-      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -3223,6 +3256,17 @@
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -3250,6 +3294,7 @@
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4212,12 +4257,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 12"
+        "node": ">= 14"
       }
     },
     "node_modules/data-urls": {
@@ -4234,10 +4280,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4300,6 +4347,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4352,6 +4400,7 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -4560,6 +4609,7 @@
       "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
       "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/which": "^2.0.1",
         "which": "^2.0.2"
@@ -4572,34 +4622,35 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.1.tgz",
-      "integrity": "sha512-/dM/PoBf22Xg3yypMWkmRQrBKEnSyNaZ7wHGCT9+qqT14izwtFT+QvdR89rjNkMfXwW+bSFoqOfbcvM+2Cyc7w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.2.0.tgz",
+      "integrity": "sha512-49G6010o0VYXUMNi5OvxqE9O/kazs0qmJVqHcSHNvp1VfojO21Kb/NaJN40uy11yrlGHRp7y6a372xoCnShzlA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "^9.1.3",
-        "@zip.js/zip.js": "^2.7.53",
-        "decamelize": "^6.0.0",
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
         "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^5.3.2",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "node-fetch": "^3.3.2",
-        "which": "^5.0.0"
+        "https-proxy-agent": "^7.0.6",
+        "which": "^6.0.0"
       },
       "bin": {
         "edgedriver": "bin/edgedriver.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/edgedriver/node_modules/decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4612,15 +4663,17 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/edgedriver/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -4628,7 +4681,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/ee-first": {
@@ -4685,10 +4738,11 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4829,6 +4883,7 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4850,6 +4905,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -5322,6 +5378,7 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -5335,21 +5392,6 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5397,9 +5439,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.2.tgz",
+      "integrity": "sha512-n8v8b6p4Z1sMgqRmqLJm3awW4NX7NkaKPfb3uJIBTSH7Pdvufi3PQ3/lJLQrvxcMYl7JI2jnDO90siPEpD8JBA==",
       "dev": true,
       "funding": [
         {
@@ -5407,8 +5449,9 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5452,31 +5495,9 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5722,18 +5743,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5816,62 +5825,38 @@
       "license": "MIT"
     },
     "node_modules/geckodriver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-5.0.0.tgz",
-      "integrity": "sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "^9.1.3",
-        "@zip.js/zip.js": "^2.7.53",
-        "decamelize": "^6.0.0",
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "node-fetch": "^3.3.2",
-        "tar-fs": "^3.0.6",
-        "which": "^5.0.0"
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.2"
       },
       "bin": {
         "geckodriver": "bin/geckodriver.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/geckodriver/node_modules/decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/geckodriver/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/geckodriver/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -5923,6 +5908,7 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
       "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -5944,25 +5930,33 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
         "debug": "^4.3.4"
       },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -6253,10 +6247,11 @@
       }
     },
     "node_modules/htmlfy": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.6.2.tgz",
-      "integrity": "sha512-dWRE+TW3QSB5mXsnYCUPLoPmaCu2O7kp6/3xh5fayiGuaNtRL/64SdjhoTBwJ2XvuSkLoMgQDLunrAqwxJj40Q==",
-      "dev": true
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -6484,10 +6479,11 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6533,23 +6529,14 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
@@ -6874,12 +6861,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
-    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
@@ -7198,6 +7179,7 @@
           "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@promptbook/utils": "0.69.5",
         "type-fest": "4.26.0",
@@ -7209,6 +7191,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
       "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -7302,6 +7285,7 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -7314,7 +7298,8 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.1.3",
@@ -7495,6 +7480,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mocha": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
@@ -7602,6 +7594,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/modern-tar": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.2.tgz",
+      "integrity": "sha512-TGG1ZRk1TAQ3neuZwahAHke3rKsSlro+ooMYtjh9sl2gGPVMLMuWiHgwC7im9T5bSM566RSo2Dko56ETgEvZcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/monaco-editor": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.20.0.tgz",
@@ -7666,6 +7668,7 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7725,43 +7728,6 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -7970,6 +7936,7 @@
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -7989,6 +7956,7 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -8223,7 +8191,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8405,6 +8374,7 @@
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -8424,6 +8394,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -8432,13 +8403,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8746,6 +8719,16 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8838,6 +8821,7 @@
       "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
       "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -8862,6 +8846,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8924,10 +8928,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8988,27 +8993,29 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
-      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "type-fest": "^2.12.2"
+        "type-fest": "^4.31.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9326,6 +9333,7 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9344,12 +9352,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -9362,6 +9371,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9492,7 +9502,8 @@
           "type": "github",
           "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
         }
-      ]
+      ],
+      "license": "Apache-2.0"
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -9556,6 +9567,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
@@ -9670,16 +9682,17 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -9741,9 +9754,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10136,10 +10149,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -10221,6 +10235,7 @@
       "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
       "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -10293,6 +10308,7 @@
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
       "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
@@ -10310,6 +10326,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10338,30 +10355,23 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webdriver": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.12.1.tgz",
-      "integrity": "sha512-gtdsfoYAVgPVlN1x3kXhPmOOzQXx6vtw9KB0LCeFQH2zUfNMB7RB1OJN475cFgSgJ7PpyvXk3CKdT1lGCHRTxQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.21.0.tgz",
+      "integrity": "sha512-XLOhpU/EFPo4TMk+0fRli4g1WriUujxrfDxGT/QRq0MJsfhSYPF8FdefFdL5gHIrJfSKscaQHGWkbnsHftfqeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.12.1",
-        "@wdio/logger": "9.4.4",
-        "@wdio/protocols": "9.7.0",
-        "@wdio/types": "9.10.1",
-        "@wdio/utils": "9.12.1",
+        "@wdio/config": "9.21.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.16.2",
+        "@wdio/types": "9.20.0",
+        "@wdio/utils": "9.21.0",
         "deepmerge-ts": "^7.0.3",
-        "undici": "^6.20.1",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.21.3",
         "ws": "^8.8.0"
       },
       "engines": {
@@ -10369,41 +10379,44 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/webdriver/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webdriverio": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.12.1.tgz",
-      "integrity": "sha512-xKasUD3DRey9lEcTAbrI29XCxLX45cxVHOIN5EJK44/thch4zhzfskdCKY3BQ9589TCkSGY1CGf8q9LFx2Ve5Q==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.21.0.tgz",
+      "integrity": "sha512-7teaXajOuNdn2UyyKlqMLssJjf0vDEih+Lo+tE/gHOt/P+mB8CinZym4PGtsriZLcyt4xV+Cun3hDmXM+pL26A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.12.1",
-        "@wdio/logger": "9.4.4",
-        "@wdio/protocols": "9.7.0",
-        "@wdio/repl": "9.4.4",
-        "@wdio/types": "9.10.1",
-        "@wdio/utils": "9.12.1",
+        "@wdio/config": "9.21.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.16.2",
+        "@wdio/repl": "9.16.2",
+        "@wdio/types": "9.20.0",
+        "@wdio/utils": "9.21.0",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
         "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.6.0",
+        "htmlfy": "^0.8.1",
         "is-plain-obj": "^4.1.0",
         "jszip": "^3.10.1",
         "lodash.clonedeep": "^4.5.0",
@@ -10411,15 +10424,15 @@
         "query-selector-shadow-dom": "^1.0.1",
         "resq": "^1.11.0",
         "rgb2hex": "0.2.5",
-        "serialize-error": "^11.0.3",
+        "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.12.1"
+        "webdriver": "9.21.0"
       },
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "puppeteer-core": "^22.3.0"
+        "puppeteer-core": ">=22.x || <=24.x"
       },
       "peerDependenciesMeta": {
         "puppeteer-core": {
@@ -11105,6 +11118,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -11115,6 +11129,7 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.3.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.5",
-        "webdriverio": "^9.12.1"
+        "webdriverio": "^9.13.0"
       },
       "peerDependencies": {
         "blockly": "^12.3.0"
@@ -1685,22 +1685,24 @@
           "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
+      "license": "CC-BY-4.0",
       "dependencies": {
         "spacetrim": "0.11.59"
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
-      "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+      "version": "2.10.13",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.13.tgz",
+      "integrity": "sha512-a9Ruw3j3qlnB5a/zHRTkruppynxqaeE4H9WNj5eYGRWqw0ZauZ23f4W2ARf3hghF5doozyD+CRtt7XSYuYRI/Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.1",
-        "tar-fs": "^3.0.8",
+        "semver": "^7.7.3",
+        "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1753,7 +1755,8 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2023,7 +2026,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
       "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -2040,6 +2044,7 @@
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -2278,14 +2283,15 @@
       "license": "ISC"
     },
     "node_modules/@wdio/config": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.12.1.tgz",
-      "integrity": "sha512-eYyF9HBQg2PyX6ScieZ5akDG4BaJmNBdYFJmwhUAGcJlxLgoI02vSqIuoWaQd5shbvtCdDzsFI0Jt8+S/xqINQ==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.20.1.tgz",
+      "integrity": "sha512-npl2J+rjCDJPjVySgWpciOyhWddn6s7n5sepKXLR7x1ADQHl5zUFv1dHD3jx4OQ9l6lrGQSPaofuz+7e9mu+vg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.10.1",
-        "@wdio/utils": "9.12.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.20.0",
+        "@wdio/utils": "9.20.1",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0"
@@ -2295,19 +2301,21 @@
       }
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2328,6 +2336,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2339,14 +2348,16 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.4.4.tgz",
-      "integrity": "sha512-BXx8RXFUW2M4dcO6t5Le95Hi2ZkTQBRsvBQqLekT2rZ6Xmw8ZKZBPf0FptnoftFGg6dYmwnDidYv/0+4PiHjpQ==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
         "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
@@ -2354,10 +2365,11 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2366,10 +2378,11 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2378,10 +2391,11 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2393,16 +2407,18 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.7.0.tgz",
-      "integrity": "sha512-5DI8cqJqT9K6oQn8UpaSTmcGAl4ufkUWC5FoPT3oXdLjILfxvweZDf/2XNBCbGMk4+VOMKqB2ofOqKhDIB2nAg==",
-      "dev": true
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.16.2.tgz",
+      "integrity": "sha512-h3k97/lzmyw5MowqceAuY3HX/wGJojXHkiPXA3WlhGPCaa2h4+GovV2nJtRvknCKsE7UHA1xB5SWeI8MzloBew==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/repl": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.4.4.tgz",
-      "integrity": "sha512-kchPRhoG/pCn4KhHGiL/ocNhdpR8OkD2e6sANlSUZ4TGBVi86YSIEjc2yXUwLacHknC/EnQk/SFnqd4MsNjGGg==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
+      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2411,25 +2427,28 @@
       }
     },
     "node_modules/@wdio/repl/node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@wdio/repl/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/types": {
-      "version": "9.10.1",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.10.1.tgz",
-      "integrity": "sha512-/t1VXPU5Ad1FQjRUP0WlK7IR0dCTX5hSkul8SpCuUpWbeyI4Iol/Wx2b1YU6nS+Ydh78rJCyHxtV0eE5TM1rbw==",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.20.0.tgz",
+      "integrity": "sha512-zMmAtse2UMCSOW76mvK3OejauAdcFGuKopNRH7crI0gwKTZtvV89yXWRziz9cVXpFgfmJCjf9edxKFWdhuF5yw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2438,36 +2457,40 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@wdio/types/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/utils": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.12.1.tgz",
-      "integrity": "sha512-WrkBdglOwKMpwvCZbOatlLUCghxNWyVfKRDyl92RBX3DuRqqq+uZK8fSHHAJMvXfax5TxcTRzHZUKrQO3ASSXw==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.20.1.tgz",
+      "integrity": "sha512-C/Gsy5NAatsGUF1eT9Ks/ErR52/X4YI7MSm7BtwNOw8v2Ko+SiCA5qXts61J0A7QYwOn4gfXfBZZnzSAng6G/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.10.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.20.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.1",
+        "edgedriver": "^6.1.2",
         "geckodriver": "^5.0.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
         "safaridriver": "^1.0.0",
         "split2": "^4.2.0",
         "wait-port": "^1.1.0"
@@ -2477,10 +2500,11 @@
       }
     },
     "node_modules/@wdio/utils/node_modules/decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2711,14 +2735,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.57",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
-      "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
+      "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
-        "node": ">=16.5.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/abab": {
@@ -3079,6 +3104,7 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -3090,7 +3116,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3161,15 +3188,18 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
-      "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz",
+      "integrity": "sha512-zGUCsm3yv/ePt2PHNbVxjjn0nNB1MkIaR4wOCxJ2ig5pCf5cCVAYJXVhQg/3OhhJV6DB1ts7Hv0oUaElc2TPQg==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -3184,10 +3214,11 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
-      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -3198,16 +3229,18 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
-      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
       "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -3223,6 +3256,17 @@
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -3250,6 +3294,7 @@
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4216,6 +4261,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -4234,10 +4280,11 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4300,6 +4347,7 @@
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4352,6 +4400,7 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -4560,6 +4609,7 @@
       "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
       "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/which": "^2.0.1",
         "which": "^2.0.2"
@@ -4572,17 +4622,18 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.1.tgz",
-      "integrity": "sha512-/dM/PoBf22Xg3yypMWkmRQrBKEnSyNaZ7wHGCT9+qqT14izwtFT+QvdR89rjNkMfXwW+bSFoqOfbcvM+2Cyc7w==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.2.tgz",
+      "integrity": "sha512-UvFqd/IR81iPyWMcxXbUNi+xKWR7JjfoHjfuwjqsj9UHQKn80RpQmS0jf+U25IPi+gKVPcpOSKm0XkqgGMq4zQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "^9.1.3",
         "@zip.js/zip.js": "^2.7.53",
         "decamelize": "^6.0.0",
         "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^5.0.8",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2",
@@ -4596,10 +4647,11 @@
       }
     },
     "node_modules/edgedriver/node_modules/decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4612,6 +4664,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
@@ -4621,6 +4674,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -4685,10 +4739,11 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4829,6 +4884,7 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4850,6 +4906,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -5322,6 +5379,7 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -5335,21 +5393,6 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5397,9 +5440,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.2.tgz",
+      "integrity": "sha512-n8v8b6p4Z1sMgqRmqLJm3awW4NX7NkaKPfb3uJIBTSH7Pdvufi3PQ3/lJLQrvxcMYl7JI2jnDO90siPEpD8JBA==",
       "dev": true,
       "funding": [
         {
@@ -5407,8 +5450,9 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5452,6 +5496,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -5471,6 +5516,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -5727,6 +5773,7 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -5821,6 +5868,7 @@
       "integrity": "sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@wdio/logger": "^9.1.3",
         "@zip.js/zip.js": "^2.7.53",
@@ -5839,10 +5887,11 @@
       }
     },
     "node_modules/geckodriver/node_modules/decamelize": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -5855,6 +5904,7 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
@@ -5864,6 +5914,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -5923,6 +5974,7 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
       "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -5944,11 +5996,28 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -5963,6 +6032,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -6253,10 +6323,11 @@
       }
     },
     "node_modules/htmlfy": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.6.2.tgz",
-      "integrity": "sha512-dWRE+TW3QSB5mXsnYCUPLoPmaCu2O7kp6/3xh5fayiGuaNtRL/64SdjhoTBwJ2XvuSkLoMgQDLunrAqwxJj40Q==",
-      "dev": true
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -6484,10 +6555,11 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6533,23 +6605,14 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
@@ -6874,12 +6937,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
-    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
@@ -7198,6 +7255,7 @@
           "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
+      "license": "Apache-2.0",
       "dependencies": {
         "@promptbook/utils": "0.69.5",
         "type-fest": "4.26.0",
@@ -7209,6 +7267,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
       "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -7302,6 +7361,7 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -7314,7 +7374,8 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.1.3",
@@ -7495,6 +7556,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mocha": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
@@ -7666,6 +7734,7 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7730,6 +7799,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
       "funding": [
         {
@@ -7741,6 +7811,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
@@ -7750,6 +7821,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -7970,6 +8042,7 @@
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -7989,6 +8062,7 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -8223,7 +8297,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8405,6 +8480,7 @@
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -8424,6 +8500,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -8432,13 +8509,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8746,6 +8825,16 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8838,6 +8927,7 @@
       "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
       "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -8862,6 +8952,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8924,10 +9034,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8988,27 +9099,29 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
-      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "type-fest": "^2.12.2"
+        "type-fest": "^4.31.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9326,6 +9439,7 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9344,12 +9458,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -9362,6 +9477,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9492,7 +9608,8 @@
           "type": "github",
           "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
         }
-      ]
+      ],
+      "license": "Apache-2.0"
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -9556,6 +9673,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
@@ -9670,16 +9788,17 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -9741,9 +9860,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
-      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10136,10 +10255,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
+      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -10221,6 +10341,7 @@
       "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
       "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -10293,6 +10414,7 @@
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
       "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
@@ -10310,6 +10432,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10343,25 +10466,28 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/webdriver": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.12.1.tgz",
-      "integrity": "sha512-gtdsfoYAVgPVlN1x3kXhPmOOzQXx6vtw9KB0LCeFQH2zUfNMB7RB1OJN475cFgSgJ7PpyvXk3CKdT1lGCHRTxQ==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.20.1.tgz",
+      "integrity": "sha512-QtvYqPai2NOnq7qePPH6kNSwk7+tnmSvnlOnY8dIT/Y24TPdQp44NjF/BUYAWIlqoBlZqHClQFTSVwT2qvO2Tw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.12.1",
-        "@wdio/logger": "9.4.4",
-        "@wdio/protocols": "9.7.0",
-        "@wdio/types": "9.10.1",
-        "@wdio/utils": "9.12.1",
+        "@wdio/config": "9.20.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.16.2",
+        "@wdio/types": "9.20.0",
+        "@wdio/utils": "9.20.1",
         "deepmerge-ts": "^7.0.3",
-        "undici": "^6.20.1",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.21.3",
         "ws": "^8.8.0"
       },
       "engines": {
@@ -10369,41 +10495,44 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/webdriver/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webdriverio": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.12.1.tgz",
-      "integrity": "sha512-xKasUD3DRey9lEcTAbrI29XCxLX45cxVHOIN5EJK44/thch4zhzfskdCKY3BQ9589TCkSGY1CGf8q9LFx2Ve5Q==",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.20.1.tgz",
+      "integrity": "sha512-QVM/asb5sDESz37ow/BAOA0z2HtUJsuAjPKHdw+Vx92PaQP3EfHwTgxK2T5rgwa0WRNh+c+n/0nEqIvqBl01sA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.12.1",
-        "@wdio/logger": "9.4.4",
-        "@wdio/protocols": "9.7.0",
-        "@wdio/repl": "9.4.4",
-        "@wdio/types": "9.10.1",
-        "@wdio/utils": "9.12.1",
+        "@wdio/config": "9.20.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.16.2",
+        "@wdio/repl": "9.16.2",
+        "@wdio/types": "9.20.0",
+        "@wdio/utils": "9.20.1",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
         "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.6.0",
+        "htmlfy": "^0.8.1",
         "is-plain-obj": "^4.1.0",
         "jszip": "^3.10.1",
         "lodash.clonedeep": "^4.5.0",
@@ -10411,15 +10540,15 @@
         "query-selector-shadow-dom": "^1.0.1",
         "resq": "^1.11.0",
         "rgb2hex": "0.2.5",
-        "serialize-error": "^11.0.3",
+        "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.12.1"
+        "webdriver": "9.20.1"
       },
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "puppeteer-core": "^22.3.0"
+        "puppeteer-core": ">=22.x || <=24.x"
       },
       "peerDependenciesMeta": {
         "puppeteer-core": {
@@ -11105,6 +11234,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -11115,6 +11245,7 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.3.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.5",
-        "webdriverio": "^9.13.0"
+        "webdriverio": "^9.12.1"
       },
       "peerDependencies": {
         "blockly": "^12.3.0"
@@ -1685,24 +1685,22 @@
           "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
-      "license": "CC-BY-4.0",
       "dependencies": {
         "spacetrim": "0.11.59"
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
-      "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
+      "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.3",
+        "debug": "^4.4.0",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3",
-        "tar-fs": "^3.1.1",
+        "semver": "^7.7.1",
+        "tar-fs": "^3.0.8",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1755,8 +1753,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2026,8 +2023,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
       "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -2044,7 +2040,6 @@
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -2283,15 +2278,14 @@
       "license": "ISC"
     },
     "node_modules/@wdio/config": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.21.0.tgz",
-      "integrity": "sha512-8TP5/q+Agjc43LET1f0LhLmuEI803O3QtZEbSxOkkvJ7/e1jDWPm4qsL7SjQJlx8xGrW0kwRlPl7+U9Sr0dhCQ==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.12.1.tgz",
+      "integrity": "sha512-eYyF9HBQg2PyX6ScieZ5akDG4BaJmNBdYFJmwhUAGcJlxLgoI02vSqIuoWaQd5shbvtCdDzsFI0Jt8+S/xqINQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.21.0",
+        "@wdio/logger": "9.4.4",
+        "@wdio/types": "9.10.1",
+        "@wdio/utils": "9.12.1",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0"
@@ -2301,21 +2295,19 @@
       }
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@wdio/config/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2336,7 +2328,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2348,16 +2339,14 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
-      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.4.4.tgz",
+      "integrity": "sha512-BXx8RXFUW2M4dcO6t5Le95Hi2ZkTQBRsvBQqLekT2rZ6Xmw8ZKZBPf0FptnoftFGg6dYmwnDidYv/0+4PiHjpQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
         "loglevel-plugin-prefix": "^0.8.4",
-        "safe-regex2": "^5.0.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
@@ -2365,11 +2354,10 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2378,11 +2366,10 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2391,11 +2378,10 @@
       }
     },
     "node_modules/@wdio/logger/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2407,18 +2393,16 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.16.2.tgz",
-      "integrity": "sha512-h3k97/lzmyw5MowqceAuY3HX/wGJojXHkiPXA3WlhGPCaa2h4+GovV2nJtRvknCKsE7UHA1xB5SWeI8MzloBew==",
-      "dev": true,
-      "license": "MIT"
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.7.0.tgz",
+      "integrity": "sha512-5DI8cqJqT9K6oQn8UpaSTmcGAl4ufkUWC5FoPT3oXdLjILfxvweZDf/2XNBCbGMk4+VOMKqB2ofOqKhDIB2nAg==",
+      "dev": true
     },
     "node_modules/@wdio/repl": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
-      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.4.4.tgz",
+      "integrity": "sha512-kchPRhoG/pCn4KhHGiL/ocNhdpR8OkD2e6sANlSUZ4TGBVi86YSIEjc2yXUwLacHknC/EnQk/SFnqd4MsNjGGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2427,28 +2411,25 @@
       }
     },
     "node_modules/@wdio/repl/node_modules/@types/node": {
-      "version": "20.19.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wdio/repl/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/@wdio/types": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.20.0.tgz",
-      "integrity": "sha512-zMmAtse2UMCSOW76mvK3OejauAdcFGuKopNRH7crI0gwKTZtvV89yXWRziz9cVXpFgfmJCjf9edxKFWdhuF5yw==",
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.10.1.tgz",
+      "integrity": "sha512-/t1VXPU5Ad1FQjRUP0WlK7IR0dCTX5hSkul8SpCuUpWbeyI4Iol/Wx2b1YU6nS+Ydh78rJCyHxtV0eE5TM1rbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -2457,40 +2438,36 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "20.19.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@wdio/types/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/@wdio/utils": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.21.0.tgz",
-      "integrity": "sha512-aj8ao2V/e6Sv9gZby2ZIj4dMLjwYVba47Nlr+pOfK8N4VKKU0VRLPzvTlfK1HWaoS6u/GBbVx2pefYRrvd72BQ==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.12.1.tgz",
+      "integrity": "sha512-WrkBdglOwKMpwvCZbOatlLUCghxNWyVfKRDyl92RBX3DuRqqq+uZK8fSHHAJMvXfax5TxcTRzHZUKrQO3ASSXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/types": "9.20.0",
+        "@wdio/logger": "9.4.4",
+        "@wdio/types": "9.10.1",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.2",
-        "geckodriver": "^6.1.0",
+        "edgedriver": "^6.1.1",
+        "geckodriver": "^5.0.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
-        "mitt": "^3.0.1",
         "safaridriver": "^1.0.0",
         "split2": "^4.2.0",
         "wait-port": "^1.1.0"
@@ -2500,11 +2477,10 @@
       }
     },
     "node_modules/@wdio/utils/node_modules/decamelize": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
-      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -2735,15 +2711,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
-      "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
+      "version": "2.7.57",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+      "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "bun": ">=0.7.0",
         "deno": ">=1.0.0",
-        "node": ">=18.0.0"
+        "node": ">=16.5.0"
       }
     },
     "node_modules/abab": {
@@ -3104,7 +3079,6 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -3116,8 +3090,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
+      "dev": true
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3188,18 +3161,15 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
-      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
+      "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
+        "bare-stream": "^2.6.4"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -3214,11 +3184,10 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -3229,18 +3198,16 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -3256,17 +3223,6 @@
         "bare-events": {
           "optional": true
         }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -3294,7 +3250,6 @@
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -4257,13 +4212,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 12"
       }
     },
     "node_modules/data-urls": {
@@ -4280,11 +4234,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4347,7 +4300,6 @@
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4400,7 +4352,6 @@
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -4609,7 +4560,6 @@
       "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
       "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/which": "^2.0.1",
         "which": "^2.0.2"
@@ -4622,35 +4572,34 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.2.0.tgz",
-      "integrity": "sha512-49G6010o0VYXUMNi5OvxqE9O/kazs0qmJVqHcSHNvp1VfojO21Kb/NaJN40uy11yrlGHRp7y6a372xoCnShzlA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.1.tgz",
+      "integrity": "sha512-/dM/PoBf22Xg3yypMWkmRQrBKEnSyNaZ7wHGCT9+qqT14izwtFT+QvdR89rjNkMfXwW+bSFoqOfbcvM+2Cyc7w==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
+        "@wdio/logger": "^9.1.3",
+        "@zip.js/zip.js": "^2.7.53",
+        "decamelize": "^6.0.0",
         "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^5.3.2",
+        "fast-xml-parser": "^4.5.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "which": "^6.0.0"
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^3.3.2",
+        "which": "^5.0.0"
       },
       "bin": {
         "edgedriver": "bin/edgedriver.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/edgedriver/node_modules/decamelize": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
-      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4663,17 +4612,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
       "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/edgedriver/node_modules/which": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
-      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -4681,7 +4628,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/ee-first": {
@@ -4738,11 +4685,10 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4883,7 +4829,6 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4905,7 +4850,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -5378,7 +5322,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -5392,6 +5335,21 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5439,9 +5397,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.2.tgz",
-      "integrity": "sha512-n8v8b6p4Z1sMgqRmqLJm3awW4NX7NkaKPfb3uJIBTSH7Pdvufi3PQ3/lJLQrvxcMYl7JI2jnDO90siPEpD8JBA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "dev": true,
       "funding": [
         {
@@ -5449,9 +5407,8 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5495,9 +5452,31 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5743,6 +5722,18 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5825,38 +5816,62 @@
       "license": "MIT"
     },
     "node_modules/geckodriver": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
-      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-5.0.0.tgz",
+      "integrity": "sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "^9.18.0",
-        "@zip.js/zip.js": "^2.8.11",
-        "decamelize": "^6.0.1",
+        "@wdio/logger": "^9.1.3",
+        "@zip.js/zip.js": "^2.7.53",
+        "decamelize": "^6.0.0",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "modern-tar": "^0.7.2"
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^3.3.2",
+        "tar-fs": "^3.0.6",
+        "which": "^5.0.0"
       },
       "bin": {
         "geckodriver": "bin/geckodriver.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/geckodriver/node_modules/decamelize": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
-      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/geckodriver/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/geckodriver/node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -5908,7 +5923,6 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
       "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -5930,33 +5944,25 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
         "debug": "^4.3.4"
       },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }
@@ -6247,11 +6253,10 @@
       }
     },
     "node_modules/htmlfy": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
-      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.6.2.tgz",
+      "integrity": "sha512-dWRE+TW3QSB5mXsnYCUPLoPmaCu2O7kp6/3xh5fayiGuaNtRL/64SdjhoTBwJ2XvuSkLoMgQDLunrAqwxJj40Q==",
+      "dev": true
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -6479,11 +6484,10 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6529,14 +6533,23 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
@@ -6861,6 +6874,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
@@ -7179,7 +7198,6 @@
           "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
         }
       ],
-      "license": "Apache-2.0",
       "dependencies": {
         "@promptbook/utils": "0.69.5",
         "type-fest": "4.26.0",
@@ -7191,7 +7209,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
       "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -7285,7 +7302,6 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
       "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -7298,8 +7314,7 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
       "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/loupe": {
       "version": "3.1.3",
@@ -7480,13 +7495,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mocha": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
@@ -7594,16 +7602,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/modern-tar": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.2.tgz",
-      "integrity": "sha512-TGG1ZRk1TAQ3neuZwahAHke3rKsSlro+ooMYtjh9sl2gGPVMLMuWiHgwC7im9T5bSM566RSo2Dko56ETgEvZcA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/monaco-editor": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.20.0.tgz",
@@ -7668,7 +7666,6 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7728,6 +7725,43 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -7936,7 +7970,6 @@
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -7956,7 +7989,6 @@
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -8191,8 +8223,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8374,7 +8405,6 @@
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -8394,7 +8424,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -8403,15 +8432,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8719,16 +8746,6 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true
     },
-    "node_modules/ret": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
-      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -8821,7 +8838,6 @@
       "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
       "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -8846,26 +8862,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-regex2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
-      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.5.0"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8928,11 +8924,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8993,29 +8988,27 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
-      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
+      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "type-fest": "^4.31.0"
+        "type-fest": "^2.12.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=16"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9333,7 +9326,6 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9352,13 +9344,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -9371,7 +9362,6 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9502,8 +9492,7 @@
           "type": "github",
           "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
         }
-      ],
-      "license": "Apache-2.0"
+      ]
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -9567,7 +9556,6 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
@@ -9682,17 +9670,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -9754,9 +9741,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10149,11 +10136,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.22.0.tgz",
-      "integrity": "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -10235,7 +10221,6 @@
       "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
       "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -10308,7 +10293,6 @@
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
       "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
@@ -10326,7 +10310,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10355,23 +10338,30 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/webdriver": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.21.0.tgz",
-      "integrity": "sha512-XLOhpU/EFPo4TMk+0fRli4g1WriUujxrfDxGT/QRq0MJsfhSYPF8FdefFdL5gHIrJfSKscaQHGWkbnsHftfqeg==",
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
-      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webdriver": {
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.12.1.tgz",
+      "integrity": "sha512-gtdsfoYAVgPVlN1x3kXhPmOOzQXx6vtw9KB0LCeFQH2zUfNMB7RB1OJN475cFgSgJ7PpyvXk3CKdT1lGCHRTxQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.21.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.16.2",
-        "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.21.0",
+        "@wdio/config": "9.12.1",
+        "@wdio/logger": "9.4.4",
+        "@wdio/protocols": "9.7.0",
+        "@wdio/types": "9.10.1",
+        "@wdio/utils": "9.12.1",
         "deepmerge-ts": "^7.0.3",
-        "https-proxy-agent": "^7.0.6",
-        "undici": "^6.21.3",
+        "undici": "^6.20.1",
         "ws": "^8.8.0"
       },
       "engines": {
@@ -10379,44 +10369,41 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "20.19.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
-      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "version": "20.17.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
+      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/webdriver/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/webdriverio": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.21.0.tgz",
-      "integrity": "sha512-7teaXajOuNdn2UyyKlqMLssJjf0vDEih+Lo+tE/gHOt/P+mB8CinZym4PGtsriZLcyt4xV+Cun3hDmXM+pL26A==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.12.1.tgz",
+      "integrity": "sha512-xKasUD3DRey9lEcTAbrI29XCxLX45cxVHOIN5EJK44/thch4zhzfskdCKY3BQ9589TCkSGY1CGf8q9LFx2Ve5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.21.0",
-        "@wdio/logger": "9.18.0",
-        "@wdio/protocols": "9.16.2",
-        "@wdio/repl": "9.16.2",
-        "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.21.0",
+        "@wdio/config": "9.12.1",
+        "@wdio/logger": "9.4.4",
+        "@wdio/protocols": "9.7.0",
+        "@wdio/repl": "9.4.4",
+        "@wdio/types": "9.10.1",
+        "@wdio/utils": "9.12.1",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
         "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.8.1",
+        "htmlfy": "^0.6.0",
         "is-plain-obj": "^4.1.0",
         "jszip": "^3.10.1",
         "lodash.clonedeep": "^4.5.0",
@@ -10424,15 +10411,15 @@
         "query-selector-shadow-dom": "^1.0.1",
         "resq": "^1.11.0",
         "rgb2hex": "0.2.5",
-        "serialize-error": "^12.0.0",
+        "serialize-error": "^11.0.3",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.21.0"
+        "webdriver": "9.12.1"
       },
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "puppeteer-core": ">=22.x || <=24.x"
+        "puppeteer-core": "^22.3.0"
       },
       "peerDependenciesMeta": {
         "puppeteer-core": {
@@ -11118,7 +11105,6 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -11129,7 +11115,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "prettier": "^3.3.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.4.5",
-        "webdriverio": "^9.13.0"
+        "webdriverio": "^9.20.1"
       },
       "peerDependencies": {
         "blockly": "^12.3.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "wdio:build:app": "cd test/webdriverio && webpack",
     "wdio:build:tests": "tsc -p ./test/webdriverio/test/tsconfig.json",
     "wdio:clean": "cd test/webdriverio/test && rm -rf dist && rm -rf failures",
-    "wdio:run": "npm run wdio:build && cd test/webdriverio/test && mkdir failures && npx mocha dist",
-    "wdio:run:ci": "npm run wdio:build && cd test/webdriverio/test && mkdir failures && npx mocha --timeout 30000 dist"
+    "wdio:run": "npm run wdio:build && cd test/webdriverio/test && mkdir -p failures && npx mocha dist",
+    "wdio:run:ci": "npm run wdio:build && cd test/webdriverio/test && mkdir -p failures && npx mocha --timeout 30000 dist"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "wdio:build": "npm run wdio:build:app && npm run wdio:build:tests",
     "wdio:build:app": "cd test/webdriverio && webpack",
     "wdio:build:tests": "tsc -p ./test/webdriverio/test/tsconfig.json",
-    "wdio:clean": "cd test/webdriverio/test && rm -rf dist",
-    "wdio:run": "npm run wdio:build && cd test/webdriverio/test && npx mocha dist",
+    "wdio:clean": "cd test/webdriverio/test && rm -rf dist && rm -rf failures",
+    "wdio:run": "npm run wdio:build && cd test/webdriverio/test && mkdir failures && npx mocha dist",
     "wdio:run:ci": "npm run wdio:build && cd test/webdriverio/test && npx mocha --timeout 30000 dist"
   },
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "^3.3.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.5",
-    "webdriverio": "^9.12.1"
+    "webdriverio": "^9.13.0"
   },
   "peerDependencies": {
     "blockly": "^12.3.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "^3.3.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.5",
-    "webdriverio": "^9.20.1"
+    "webdriverio": "^9.12.1"
   },
   "peerDependencies": {
     "blockly": "^12.3.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "^3.3.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.5",
-    "webdriverio": "^9.13.0"
+    "webdriverio": "^9.12.1"
   },
   "peerDependencies": {
     "blockly": "^12.3.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "wdio:build:tests": "tsc -p ./test/webdriverio/test/tsconfig.json",
     "wdio:clean": "cd test/webdriverio/test && rm -rf dist && rm -rf failures",
     "wdio:run": "npm run wdio:build && cd test/webdriverio/test && mkdir failures && npx mocha dist",
-    "wdio:run:ci": "npm run wdio:build && cd test/webdriverio/test && npx mocha --timeout 30000 dist"
+    "wdio:run:ci": "npm run wdio:build && cd test/webdriverio/test && mkdir failures && npx mocha --timeout 30000 dist"
   },
   "main": "./dist/index.js",
   "module": "./src/index.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "npm login --registry https://wombat-dressing-room.appspot.com",
     "start": "blockly-scripts start",
     "test": "npm run test:mocha && npm run test:wdio",
-    "test:ci": "npm run test:mocha && npm run test:wdio:ci",
+    "test:ci": "npm run test:wdio:ci",
     "test:mocha": "blockly-scripts test",
     "test:wdio": "npm run wdio:clean && npm run wdio:run",
     "test:wdio:ci": "npm run wdio:clean && npm run wdio:run:ci",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "npm login --registry https://wombat-dressing-room.appspot.com",
     "start": "blockly-scripts start",
     "test": "npm run test:mocha && npm run test:wdio",
-    "test:ci": "npm run test:wdio:ci",
+    "test:ci": "npm run test:mocha && npm run test:wdio:ci",
     "test:mocha": "blockly-scripts test",
     "test:wdio": "npm run wdio:clean && npm run wdio:run",
     "test:wdio:ci": "npm run wdio:clean && npm run wdio:run:ci",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "^3.3.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.5",
-    "webdriverio": "^9.13.0"
+    "webdriverio": "^9.20.1"
   },
   "peerDependencies": {
     "blockly": "^12.3.0"

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -20,6 +20,7 @@ import {
   sendKeyAndWait,
   keyRight,
   contextMenuItems,
+  checkForFailures,
 } from './test_setup.js';
 
 const isDarwin = process.platform === 'darwin';
@@ -97,6 +98,10 @@ suite('Menus test', function () {
       this.timeout(),
     );
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Menu action via keyboard on block opens menu', async function () {

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -88,7 +88,7 @@ const workspaceActionsViaKeyboard = [
   {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
 ];
 
-suite.only('Menus test', function () {
+suite('Menus test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -104,7 +104,7 @@ suite('Menus test', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -21,6 +21,7 @@ import {
   keyRight,
   contextMenuItems,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 
 const isDarwin = process.platform === 'darwin';
@@ -97,7 +98,7 @@ suite('Menus test', function () {
       testFileLocations.MORE_BLOCKS,
       this.timeout(),
     );
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -107,7 +108,7 @@ suite('Menus test', function () {
   test('Menu action via keyboard on block opens menu', async function () {
     // Navigate to draw_circle_1.
     await focusOnBlock(this.browser, 'draw_circle_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
@@ -131,7 +132,7 @@ suite('Menus test', function () {
     await focusOnBlock(this.browser, 'text_print_1');
     await this.browser.keys(Key.ArrowRight);
     await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai.assert.deepEqual(
       await contextMenuItems(this.browser),
@@ -159,9 +160,9 @@ suite('Menus test', function () {
     await moveToToolboxCategory(this.browser, 'Math');
     // Move to flyout.
     await keyRight(this.browser);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await rightClickOnFlyoutBlockType(this.browser, 'math_number');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai.assert.deepEqual(
       await contextMenuItems(this.browser),
@@ -197,11 +198,11 @@ suite('Menus test', function () {
   test('Escape key dismisses menu', async function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await this.browser.keys([Key.Ctrl, Key.Return]);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await this.browser.keys(Key.Escape);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Duplicate', /* reverse= */ true),
@@ -212,9 +213,9 @@ suite('Menus test', function () {
   test('Clicking workspace dismisses menu', async function () {
     await tabNavigateToWorkspace(this.browser);
     await clickBlock(this.browser, 'draw_circle_1', {button: 'right'});
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await focusWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Duplicate', /* reverse= */ true),

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -21,7 +21,7 @@ import {
   keyRight,
   contextMenuItems,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 
 const isDarwin = process.platform === 'darwin';
@@ -98,17 +98,21 @@ suite('Menus test', function () {
       testFileLocations.MORE_BLOCKS,
       this.timeout(),
     );
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Menu action via keyboard on block opens menu', async function () {
     // Navigate to draw_circle_1.
     await focusOnBlock(this.browser, 'draw_circle_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await sendKeyAndWait(this.browser, [Key.Ctrl, Key.Return]);
 
     chai.assert.deepEqual(
@@ -132,7 +136,7 @@ suite('Menus test', function () {
     await focusOnBlock(this.browser, 'text_print_1');
     await this.browser.keys(Key.ArrowRight);
     await this.browser.keys([Key.Ctrl, Key.Return]);
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai.assert.deepEqual(
       await contextMenuItems(this.browser),
@@ -160,9 +164,9 @@ suite('Menus test', function () {
     await moveToToolboxCategory(this.browser, 'Math');
     // Move to flyout.
     await keyRight(this.browser);
-    await idle(this.browser);
+    await pause(this.browser);
     await rightClickOnFlyoutBlockType(this.browser, 'math_number');
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai.assert.deepEqual(
       await contextMenuItems(this.browser),
@@ -198,11 +202,11 @@ suite('Menus test', function () {
   test('Escape key dismisses menu', async function () {
     await tabNavigateToWorkspace(this.browser);
     await focusOnBlock(this.browser, 'draw_circle_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await this.browser.keys([Key.Ctrl, Key.Return]);
-    await idle(this.browser);
+    await pause(this.browser);
     await this.browser.keys(Key.Escape);
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Duplicate', /* reverse= */ true),
@@ -213,9 +217,9 @@ suite('Menus test', function () {
   test('Clicking workspace dismisses menu', async function () {
     await tabNavigateToWorkspace(this.browser);
     await clickBlock(this.browser, 'draw_circle_1', {button: 'right'});
-    await idle(this.browser);
+    await pause(this.browser);
     await focusWorkspace(this.browser);
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai.assert.isTrue(
       await contextMenuExists(this.browser, 'Duplicate', /* reverse= */ true),

--- a/test/webdriverio/test/actions_test.ts
+++ b/test/webdriverio/test/actions_test.ts
@@ -88,7 +88,7 @@ const workspaceActionsViaKeyboard = [
   {'disabled': true, 'text': isDarwin ? 'Paste ⌘ V' : 'Paste Ctrl + V'},
 ];
 
-suite('Menus test', function () {
+suite.only('Menus test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -27,7 +27,7 @@ import {
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
-suite.only('Keyboard navigation on Blocks', function () {
+suite('Keyboard navigation on Blocks', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 
@@ -229,7 +229,7 @@ suite.only('Keyboard navigation on Blocks', function () {
   });
 });
 
-suite.only('Keyboard navigation on Fields', function () {
+suite('Keyboard navigation on Fields', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -23,6 +23,7 @@ import {
   keyUp,
   keyDown,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -52,7 +53,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Selected block', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     await keyDown(this.browser, 14);
 
@@ -63,7 +64,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Down from statement block selects next block across stacks', async function () {
     await focusOnBlock(this.browser, 'p5_canvas_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -73,7 +74,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Up from statement block selects previous block', async function () {
     await focusOnBlock(this.browser, 'simple_circle_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyUp(this.browser);
 
     chai
@@ -83,7 +84,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Down from parent block selects first child block', async function () {
     await focusOnBlock(this.browser, 'p5_setup_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyDown(this.browser);
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -92,7 +93,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Up from child block selects parent block', async function () {
     await focusOnBlock(this.browser, 'p5_canvas_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyUp(this.browser);
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -101,7 +102,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from block selects first field', async function () {
     await focusOnBlock(this.browser, 'p5_canvas_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -113,7 +114,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from block selects first inline input', async function () {
     await focusOnBlock(this.browser, 'simple_circle_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyRight(this.browser);
 
     chai.assert.equal(
@@ -124,7 +125,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Up from inline input selects statement block', async function () {
     await focusOnBlock(this.browser, 'math_number_2');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyUp(this.browser);
 
     chai.assert.equal(
@@ -135,7 +136,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Left from first inline input selects block', async function () {
     await focusOnBlock(this.browser, 'math_number_2');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyLeft(this.browser);
 
     chai.assert.equal(
@@ -146,7 +147,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from first inline input selects second inline input', async function () {
     await focusOnBlock(this.browser, 'math_number_2');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyRight(this.browser);
 
     chai.assert.equal(
@@ -157,7 +158,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Left from second inline input selects first inline input', async function () {
     await focusOnBlock(this.browser, 'math_number_3');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyLeft(this.browser);
 
     chai.assert.equal(
@@ -168,7 +169,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from last inline input selects next block', async function () {
     await focusOnBlock(this.browser, 'colour_picker_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -178,7 +179,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Down from inline input selects next block', async function () {
     await focusOnBlock(this.browser, 'colour_picker_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -188,7 +189,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test("Down from inline input selects block's child block", async function () {
     await focusOnBlock(this.browser, 'logic_boolean_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -198,7 +199,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from text block selects shadow block then field', async function () {
     await focusOnBlock(this.browser, 'text_print_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyRight(this.browser);
 
     chai.assert.equal(await getCurrentFocusedBlockId(this.browser), 'text_1');
@@ -246,7 +247,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Up from first field selects block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyUp(this.browser);
 
     chai.assert.equal(
@@ -257,7 +258,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Left from first field selects block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyLeft(this.browser);
 
     chai.assert.equal(
@@ -268,7 +269,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Right from first field selects second field', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -280,7 +281,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Left from second field selects first field', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyLeft(this.browser);
 
     chai
@@ -292,7 +293,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Right from second field selects next block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -302,7 +303,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Down from field selects next block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -312,7 +313,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test("Down from field selects block's child block", async function () {
     await focusOnBlockField(this.browser, 'controls_repeat_1', 'TIMES');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -323,7 +324,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Do not navigate while field editor is open', async function () {
     // Open a field editor dropdown
     await focusOnBlockField(this.browser, 'logic_boolean_1', 'BOOL');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to navigate to a different block
@@ -336,7 +337,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Do not reopen field editor when handling enter to make a choice inside the editor', async function () {
     // Open colour picker
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Move right to pick a new colour.

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -42,7 +42,7 @@ suite('Keyboard navigation on Blocks', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });
@@ -248,7 +248,7 @@ suite('Keyboard navigation on Fields', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -23,7 +23,7 @@ import {
   keyUp,
   keyDown,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -39,8 +39,12 @@ suite('Keyboard navigation on Blocks', function () {
     );
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Default workspace', async function () {
@@ -53,7 +57,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Selected block', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await idle(this.browser);
+    await pause(this.browser);
 
     await keyDown(this.browser, 14);
 
@@ -64,7 +68,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Down from statement block selects next block across stacks', async function () {
     await focusOnBlock(this.browser, 'p5_canvas_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -74,7 +78,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Up from statement block selects previous block', async function () {
     await focusOnBlock(this.browser, 'simple_circle_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyUp(this.browser);
 
     chai
@@ -84,7 +88,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Down from parent block selects first child block', async function () {
     await focusOnBlock(this.browser, 'p5_setup_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyDown(this.browser);
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -93,7 +97,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Up from child block selects parent block', async function () {
     await focusOnBlock(this.browser, 'p5_canvas_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyUp(this.browser);
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
@@ -102,7 +106,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from block selects first field', async function () {
     await focusOnBlock(this.browser, 'p5_canvas_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -114,7 +118,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from block selects first inline input', async function () {
     await focusOnBlock(this.browser, 'simple_circle_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyRight(this.browser);
 
     chai.assert.equal(
@@ -125,7 +129,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Up from inline input selects statement block', async function () {
     await focusOnBlock(this.browser, 'math_number_2');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyUp(this.browser);
 
     chai.assert.equal(
@@ -136,7 +140,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Left from first inline input selects block', async function () {
     await focusOnBlock(this.browser, 'math_number_2');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyLeft(this.browser);
 
     chai.assert.equal(
@@ -147,7 +151,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from first inline input selects second inline input', async function () {
     await focusOnBlock(this.browser, 'math_number_2');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyRight(this.browser);
 
     chai.assert.equal(
@@ -158,7 +162,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Left from second inline input selects first inline input', async function () {
     await focusOnBlock(this.browser, 'math_number_3');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyLeft(this.browser);
 
     chai.assert.equal(
@@ -169,7 +173,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from last inline input selects next block', async function () {
     await focusOnBlock(this.browser, 'colour_picker_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -179,7 +183,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Down from inline input selects next block', async function () {
     await focusOnBlock(this.browser, 'colour_picker_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -189,7 +193,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test("Down from inline input selects block's child block", async function () {
     await focusOnBlock(this.browser, 'logic_boolean_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -199,7 +203,7 @@ suite('Keyboard navigation on Blocks', function () {
 
   test('Right from text block selects shadow block then field', async function () {
     await focusOnBlock(this.browser, 'text_print_1');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyRight(this.browser);
 
     chai.assert.equal(await getCurrentFocusedBlockId(this.browser), 'text_1');
@@ -241,13 +245,17 @@ suite('Keyboard navigation on Fields', function () {
     );
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Up from first field selects block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyUp(this.browser);
 
     chai.assert.equal(
@@ -258,7 +266,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Left from first field selects block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyLeft(this.browser);
 
     chai.assert.equal(
@@ -269,7 +277,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Right from first field selects second field', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -281,7 +289,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Left from second field selects first field', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyLeft(this.browser);
 
     chai
@@ -293,7 +301,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Right from second field selects next block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'HEIGHT');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyRight(this.browser);
 
     chai
@@ -303,7 +311,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test('Down from field selects next block', async function () {
     await focusOnBlockField(this.browser, 'p5_canvas_1', 'WIDTH');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -313,7 +321,7 @@ suite('Keyboard navigation on Fields', function () {
 
   test("Down from field selects block's child block", async function () {
     await focusOnBlockField(this.browser, 'controls_repeat_1', 'TIMES');
-    await idle(this.browser);
+    await pause(this.browser);
     await keyDown(this.browser);
 
     chai
@@ -324,7 +332,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Do not navigate while field editor is open', async function () {
     // Open a field editor dropdown
     await focusOnBlockField(this.browser, 'logic_boolean_1', 'BOOL');
-    await idle(this.browser);
+    await pause(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to navigate to a different block
@@ -337,7 +345,7 @@ suite('Keyboard navigation on Fields', function () {
   test('Do not reopen field editor when handling enter to make a choice inside the editor', async function () {
     // Open colour picker
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
-    await idle(this.browser);
+    await pause(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Move right to pick a new colour.

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -22,6 +22,7 @@ import {
   keyRight,
   keyUp,
   keyDown,
+  checkForFailures,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -35,6 +36,10 @@ suite('Keyboard navigation on Blocks', function () {
       testFileLocations.NAVIGATION_TEST_BLOCKS,
       this.timeout(),
     );
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Default workspace', async function () {
@@ -233,6 +238,10 @@ suite('Keyboard navigation on Fields', function () {
       testFileLocations.NAVIGATION_TEST_BLOCKS,
       this.timeout(),
     );
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Up from first field selects block', async function () {

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -27,7 +27,7 @@ import {
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
-suite('Keyboard navigation on Blocks', function () {
+suite.only('Keyboard navigation on Blocks', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 
@@ -229,7 +229,7 @@ suite('Keyboard navigation on Blocks', function () {
   });
 });
 
-suite('Keyboard navigation on Fields', function () {
+suite.only('Keyboard navigation on Fields', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -38,7 +38,7 @@ suite('Block comment navigation', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -18,7 +18,7 @@ import {
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
-suite.only('Block comment navigation', function () {
+suite('Block comment navigation', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -35,8 +35,12 @@ suite('Block comment navigation', function () {
     });
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Activating a block comment icon focuses the comment', async function () {

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -18,7 +18,7 @@ import {
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
-suite('Block comment navigation', function () {
+suite.only('Block comment navigation', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/block_comment_test.ts
+++ b/test/webdriverio/test/block_comment_test.ts
@@ -14,6 +14,7 @@ import {
   testFileLocations,
   keyRight,
   PAUSE_TIME,
+  checkForFailures,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -32,6 +33,10 @@ suite('Block comment navigation', function () {
         .getBlockById('p5_canvas_1')
         ?.setCommentText('test comment');
     });
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Activating a block comment icon focuses the comment', async function () {

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -19,6 +19,7 @@ import {
   getFocusedBlockType,
   sendKeyAndWait,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
@@ -29,7 +30,7 @@ suite('Clipboard test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -117,7 +118,7 @@ suite('Clipboard test', function () {
   test('Do not cut block while field editor is open', async function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'draw_circle_1_color', 'COLOUR');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to cut block while field editor is open
@@ -171,7 +172,7 @@ async function performActionWhileDraggingBlock(
       .move(blockX, blockY),
     action,
   ]);
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 }
 
 /**

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -36,7 +36,7 @@ suite('Clipboard test', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -19,7 +19,7 @@ import {
   getFocusedBlockType,
   sendKeyAndWait,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
@@ -30,11 +30,15 @@ suite('Clipboard test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Copy and paste while block selected', async function () {
@@ -118,7 +122,7 @@ suite('Clipboard test', function () {
   test('Do not cut block while field editor is open', async function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'draw_circle_1_color', 'COLOUR');
-    await idle(this.browser);
+    await pause(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to cut block while field editor is open
@@ -172,7 +176,7 @@ async function performActionWhileDraggingBlock(
       .move(blockX, blockY),
     action,
   ]);
-  await idle(browser);
+  await pause(browser);
 }
 
 /**

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -23,7 +23,7 @@ import {
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
-suite('Clipboard test', function () {
+suite.only('Clipboard test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -18,6 +18,7 @@ import {
   blockIsPresent,
   getFocusedBlockType,
   sendKeyAndWait,
+  checkForFailures,
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
@@ -29,6 +30,10 @@ suite('Clipboard test', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Copy and paste while block selected', async function () {

--- a/test/webdriverio/test/clipboard_test.ts
+++ b/test/webdriverio/test/clipboard_test.ts
@@ -23,7 +23,7 @@ import {
 } from './test_setup.js';
 import {Key, KeyAction, PointerAction, WheelAction} from 'webdriverio';
 
-suite.only('Clipboard test', function () {
+suite('Clipboard test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -23,7 +23,7 @@ import {
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
-suite('Deleting Blocks', function () {
+suite.only('Deleting Blocks', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -19,7 +19,7 @@ import {
   keyRight,
   focusOnBlockField,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -33,16 +33,20 @@ suite('Deleting Blocks', function () {
       testFileLocations.NAVIGATION_TEST_BLOCKS,
       this.timeout(),
     );
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Deleting block selects parent block', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -61,7 +65,7 @@ suite('Deleting Blocks', function () {
 
   test('Cutting block selects parent block', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -80,7 +84,7 @@ suite('Deleting Blocks', function () {
 
   test('Deleting block also deletes children and inputs', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -99,7 +103,7 @@ suite('Deleting Blocks', function () {
 
   test('Cutting block also removes children and inputs', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -118,7 +122,7 @@ suite('Deleting Blocks', function () {
 
   test('Deleting inline input selects parent block', async function () {
     await focusOnBlock(this.browser, 'logic_boolean_1');
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -137,7 +141,7 @@ suite('Deleting Blocks', function () {
 
   test('Cutting inline input selects parent block', async function () {
     await focusOnBlock(this.browser, 'logic_boolean_1');
-    await idle(this.browser);
+    await pause(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -161,11 +165,11 @@ suite('Deleting Blocks', function () {
     // We want deleting a block to focus the workspace, whatever that
     // means at the time.
     await tabNavigateToWorkspace(this.browser);
-    await idle(this.browser);
+    await pause(this.browser);
 
     // The test workspace doesn't already contain a stranded block, so add one.
     await moveToToolboxCategory(this.browser, 'Math');
-    await idle(this.browser);
+    await pause(this.browser);
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
@@ -185,11 +189,11 @@ suite('Deleting Blocks', function () {
 
   test('Cutting stranded block selects top block', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await idle(this.browser);
+    await pause(this.browser);
 
     // The test workspace doesn't already contain a stranded block, so add one.
     await moveToToolboxCategory(this.browser, 'Math');
-    await idle(this.browser);
+    await pause(this.browser);
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
@@ -210,7 +214,7 @@ suite('Deleting Blocks', function () {
   test('Do not delete block while field editor is open', async function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
-    await idle(this.browser);
+    await pause(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to delete block while field editor is open

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -39,7 +39,7 @@ suite('Deleting Blocks', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -23,7 +23,7 @@ import {
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
-suite.only('Deleting Blocks', function () {
+suite('Deleting Blocks', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -19,6 +19,7 @@ import {
   keyRight,
   focusOnBlockField,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -32,7 +33,7 @@ suite('Deleting Blocks', function () {
       testFileLocations.NAVIGATION_TEST_BLOCKS,
       this.timeout(),
     );
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -41,7 +42,7 @@ suite('Deleting Blocks', function () {
 
   test('Deleting block selects parent block', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -60,7 +61,7 @@ suite('Deleting Blocks', function () {
 
   test('Cutting block selects parent block', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'controls_if_2'))
@@ -79,7 +80,7 @@ suite('Deleting Blocks', function () {
 
   test('Deleting block also deletes children and inputs', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -98,7 +99,7 @@ suite('Deleting Blocks', function () {
 
   test('Cutting block also removes children and inputs', async function () {
     await focusOnBlock(this.browser, 'controls_if_2');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -117,7 +118,7 @@ suite('Deleting Blocks', function () {
 
   test('Deleting inline input selects parent block', async function () {
     await focusOnBlock(this.browser, 'logic_boolean_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -136,7 +137,7 @@ suite('Deleting Blocks', function () {
 
   test('Cutting inline input selects parent block', async function () {
     await focusOnBlock(this.browser, 'logic_boolean_1');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     chai
       .expect(await blockIsPresent(this.browser, 'logic_boolean_1'))
@@ -160,11 +161,11 @@ suite('Deleting Blocks', function () {
     // We want deleting a block to focus the workspace, whatever that
     // means at the time.
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     // The test workspace doesn't already contain a stranded block, so add one.
     await moveToToolboxCategory(this.browser, 'Math');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
@@ -184,11 +185,11 @@ suite('Deleting Blocks', function () {
 
   test('Cutting stranded block selects top block', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     // The test workspace doesn't already contain a stranded block, so add one.
     await moveToToolboxCategory(this.browser, 'Math');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     // Move to flyout.
     await keyRight(this.browser);
     // Select number block.
@@ -209,7 +210,7 @@ suite('Deleting Blocks', function () {
   test('Do not delete block while field editor is open', async function () {
     // Open a field editor
     await focusOnBlockField(this.browser, 'colour_picker_1', 'COLOUR');
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
 
     // Try to delete block while field editor is open

--- a/test/webdriverio/test/delete_test.ts
+++ b/test/webdriverio/test/delete_test.ts
@@ -18,6 +18,7 @@ import {
   sendKeyAndWait,
   keyRight,
   focusOnBlockField,
+  checkForFailures,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -32,6 +33,10 @@ suite('Deleting Blocks', function () {
       this.timeout(),
     );
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Deleting block selects parent block', async function () {

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -19,7 +19,7 @@ import {
   idle,
 } from './test_setup.js';
 
-suite('Duplicate test', function () {
+suite.only('Duplicate test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -15,6 +15,7 @@ import {
   testFileLocations,
   testSetup,
   sendKeyAndWait,
+  checkForFailures,
 } from './test_setup.js';
 
 suite('Duplicate test', function () {
@@ -25,6 +26,10 @@ suite('Duplicate test', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Duplicate block', async function () {

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -32,7 +32,7 @@ suite('Duplicate test', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -16,7 +16,7 @@ import {
   testSetup,
   sendKeyAndWait,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 
 suite('Duplicate test', function () {
@@ -26,11 +26,15 @@ suite('Duplicate test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Duplicate block', async function () {
@@ -67,7 +71,7 @@ suite('Duplicate test', function () {
         (workspace as Blockly.WorkspaceSvg).getTopComments()[0],
       );
     }, text);
-    await idle(this.browser);
+    await pause(this.browser);
 
     // Duplicate.
     await sendKeyAndWait(this.browser, 'd');

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -16,6 +16,7 @@ import {
   testSetup,
   sendKeyAndWait,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 
 suite('Duplicate test', function () {
@@ -25,7 +26,7 @@ suite('Duplicate test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -66,7 +67,7 @@ suite('Duplicate test', function () {
         (workspace as Blockly.WorkspaceSvg).getTopComments()[0],
       );
     }, text);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     // Duplicate.
     await sendKeyAndWait(this.browser, 'd');

--- a/test/webdriverio/test/duplicate_test.ts
+++ b/test/webdriverio/test/duplicate_test.ts
@@ -19,7 +19,7 @@ import {
   idle,
 } from './test_setup.js';
 
-suite.only('Duplicate test', function () {
+suite('Duplicate test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -305,10 +305,10 @@ suite.only('Toolbox and flyout test', function () {
       // First thing in the toolbox is the first button
       // Press Enter to activate it.
       await keyRight(this.browser);
-      // await sendKeyAndWait(this.browser, webdriverio.Key.Enter);
+      await sendKeyAndWait(this.browser, webdriverio.Key.Enter);
 
       // This errors if there is no alert present
-      // await this.browser.getAlertText();
+      await this.browser.getAlertText();
     });
 
     test.skip('callbackKey is activated with enter', async function () {

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -25,7 +25,7 @@ import {
   setSynchronizeCoreBlocklyRendering,
 } from './test_setup.js';
 
-suite('Toolbox and flyout test', function () {
+suite.only('Toolbox and flyout test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -302,6 +302,8 @@ suite('Toolbox and flyout test', function () {
       }
     });
     test('callbackkey is activated with enter', async function () {
+      // Rendering synchronization must be disabled since this test opens an
+      // alert dialog. See the function's documentation for more specifics.
       setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
       await pause(this.browser);
@@ -316,6 +318,8 @@ suite('Toolbox and flyout test', function () {
     });
 
     test('callbackKey is activated with enter', async function () {
+      // Rendering synchronization must be disabled since this test opens an
+      // alert dialog. See the function's documentation for more specifics.
       setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
       await pause(this.browser);

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -25,7 +25,7 @@ import {
   setSynchronizeCoreBlocklyRendering,
 } from './test_setup.js';
 
-suite.only('Toolbox and flyout test', function () {
+suite('Toolbox and flyout test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 
@@ -39,7 +39,7 @@ suite.only('Toolbox and flyout test', function () {
     await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
-  test.skip('Tab navigating to toolbox should open flyout', async function () {
+  test('Tab navigating to toolbox should open flyout', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped).
     await tabNavigateForward(this.browser);
 
@@ -50,7 +50,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isTrue(flyoutIsOpen);
   });
 
-  test.skip('Tab navigating to flyout should auto-select first block', async function () {
+  test('Tab navigating to flyout should auto-select first block', async function () {
     // Three tabs should navigate to the flyout (initial element is skipped).
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -63,7 +63,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'if_block');
   });
 
-  test.skip('Tab navigating to toolbox then right arrow key should auto-select first block in flyout', async function () {
+  test('Tab navigating to toolbox then right arrow key should auto-select first block in flyout', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped). One
     // right arrow key should select a block on the flyout.
     await tabNavigateForward(this.browser);
@@ -77,7 +77,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'if_block');
   });
 
-  test.skip('Keyboard nav to different toolbox category should auto-select first block', async function () {
+  test('Keyboard nav to different toolbox category should auto-select first block', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped),
     // then keys for a different category with a tab to select the flyout.
     await tabNavigateForward(this.browser);
@@ -91,7 +91,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'text_block');
   });
 
-  test.skip('Keyboard nav to different toolbox category and block should select different block', async function () {
+  test('Keyboard nav to different toolbox category and block should select different block', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped),
     // then keys for a different category with a tab to select the flyout and
     // finally keys to select a different block.
@@ -107,7 +107,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'append_text_block');
   });
 
-  test.skip('Tab navigate away from toolbox restores focus to initial element', async function () {
+  test('Tab navigate away from toolbox restores focus to initial element', async function () {
     // Two tabs should navigate to the toolbox. One tab back should leave it.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -122,7 +122,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(activeElementId, 'focusableDiv');
   });
 
-  test.skip('Tab navigate away from toolbox closes flyout', async function () {
+  test('Tab navigate away from toolbox closes flyout', async function () {
     // Two tabs should navigate to the toolbox. One tab back should leave it.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -135,7 +135,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test.skip('Tab navigate away from flyout to toolbox and away closes flyout', async function () {
+  test('Tab navigate away from flyout to toolbox and away closes flyout', async function () {
     // Three tabs should navigate to the flyout, and two tabs back should close.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -149,7 +149,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test.skip('Tabbing to the workspace should close the flyout', async function () {
+  test('Tabbing to the workspace should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
     await idle(this.browser);
 
@@ -158,7 +158,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test.skip('Tabbing to the workspace after selecting flyout block should close the flyout', async function () {
+  test('Tabbing to the workspace after selecting flyout block should close the flyout', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped),
     // then use right key to specifically navigate into the flyout before
     // navigating to the workspace.
@@ -174,7 +174,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test.skip('Tabbing to the workspace after selecting flyout block via workspace toolbox shortcut should close the flyout', async function () {
+  test('Tabbing to the workspace after selecting flyout block via workspace toolbox shortcut should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
 
     await sendKeyAndWait(this.browser, 't');
@@ -187,7 +187,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test.skip('Tabbing back from workspace should reopen the flyout', async function () {
+  test('Tabbing back from workspace should reopen the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
 
     await tabNavigateBackward(this.browser);
@@ -198,7 +198,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isTrue(flyoutIsOpen);
   });
 
-  test.skip('Navigation position in workspace should be retained when tabbing to flyout and back', async function () {
+  test('Navigation position in workspace should be retained when tabbing to flyout and back', async function () {
     // Navigate to the workspace and select a non-default block.
     await tabNavigateToWorkspace(this.browser);
 
@@ -214,7 +214,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'p5_draw_1');
   });
 
-  test.skip('Clicking outside Blockly with focused toolbox closes the flyout', async function () {
+  test('Clicking outside Blockly with focused toolbox closes the flyout', async function () {
     // Two tabs should navigate to the toolbox. One click to unfocus.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -227,7 +227,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test.skip('Clicking outside Blockly with focused flyout closes the flyout', async function () {
+  test('Clicking outside Blockly with focused flyout closes the flyout', async function () {
     // Two tabs should navigate to the toolbox. One key to select the flyout.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -242,7 +242,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test.skip('Clicking on toolbox category focuses it and opens flyout', async function () {
+  test('Clicking on toolbox category focuses it and opens flyout', async function () {
     const elemId = await findToolboxCategoryIdByName(this.browser, 'Loops');
     const elem = this.browser.$(`#${elemId}`);
     await elem.click();
@@ -311,7 +311,7 @@ suite.only('Toolbox and flyout test', function () {
       await this.browser.getAlertText();
     });
 
-    test.skip('callbackKey is activated with enter', async function () {
+    test('callbackKey is activated with enter', async function () {
       setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
       await idle(this.browser);

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -308,7 +308,7 @@ suite.only('Toolbox and flyout test', function () {
       await sendKeyAndWait(this.browser, webdriverio.Key.Enter);
 
       // This errors if there is no alert present
-      await this.browser.getAlertText();
+      // await this.browser.getAlertText();
     });
 
     test.skip('callbackKey is activated with enter', async function () {

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -39,7 +39,7 @@ suite.only('Toolbox and flyout test', function () {
     await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
-  test('Tab navigating to toolbox should open flyout', async function () {
+  test.skip('Tab navigating to toolbox should open flyout', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped).
     await tabNavigateForward(this.browser);
 
@@ -50,7 +50,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isTrue(flyoutIsOpen);
   });
 
-  test('Tab navigating to flyout should auto-select first block', async function () {
+  test.skip('Tab navigating to flyout should auto-select first block', async function () {
     // Three tabs should navigate to the flyout (initial element is skipped).
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -63,7 +63,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'if_block');
   });
 
-  test('Tab navigating to toolbox then right arrow key should auto-select first block in flyout', async function () {
+  test.skip('Tab navigating to toolbox then right arrow key should auto-select first block in flyout', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped). One
     // right arrow key should select a block on the flyout.
     await tabNavigateForward(this.browser);
@@ -77,7 +77,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'if_block');
   });
 
-  test('Keyboard nav to different toolbox category should auto-select first block', async function () {
+  test.skip('Keyboard nav to different toolbox category should auto-select first block', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped),
     // then keys for a different category with a tab to select the flyout.
     await tabNavigateForward(this.browser);
@@ -91,7 +91,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'text_block');
   });
 
-  test('Keyboard nav to different toolbox category and block should select different block', async function () {
+  test.skip('Keyboard nav to different toolbox category and block should select different block', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped),
     // then keys for a different category with a tab to select the flyout and
     // finally keys to select a different block.
@@ -107,7 +107,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'append_text_block');
   });
 
-  test('Tab navigate away from toolbox restores focus to initial element', async function () {
+  test.skip('Tab navigate away from toolbox restores focus to initial element', async function () {
     // Two tabs should navigate to the toolbox. One tab back should leave it.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -122,7 +122,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(activeElementId, 'focusableDiv');
   });
 
-  test('Tab navigate away from toolbox closes flyout', async function () {
+  test.skip('Tab navigate away from toolbox closes flyout', async function () {
     // Two tabs should navigate to the toolbox. One tab back should leave it.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -135,7 +135,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test('Tab navigate away from flyout to toolbox and away closes flyout', async function () {
+  test.skip('Tab navigate away from flyout to toolbox and away closes flyout', async function () {
     // Three tabs should navigate to the flyout, and two tabs back should close.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -254,7 +254,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isTrue(flyoutIsOpen);
   });
 
-  suite.skip('Flyout buttons', function () {
+  suite('Flyout buttons', function () {
     setup(async function () {
       // New toolbox definition
       const toolbox = {

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -254,7 +254,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isTrue(flyoutIsOpen);
   });
 
-  suite('Flyout buttons', function () {
+  suite.skip('Flyout buttons', function () {
     setup(async function () {
       // New toolbox definition
       const toolbox = {

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -149,7 +149,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test('Tabbing to the workspace should close the flyout', async function () {
+  test.skip('Tabbing to the workspace should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
     await idle(this.browser);
 
@@ -158,7 +158,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test('Tabbing to the workspace after selecting flyout block should close the flyout', async function () {
+  test.skip('Tabbing to the workspace after selecting flyout block should close the flyout', async function () {
     // Two tabs should navigate to the toolbox (initial element is skipped),
     // then use right key to specifically navigate into the flyout before
     // navigating to the workspace.
@@ -174,7 +174,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test('Tabbing to the workspace after selecting flyout block via workspace toolbox shortcut should close the flyout', async function () {
+  test.skip('Tabbing to the workspace after selecting flyout block via workspace toolbox shortcut should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
 
     await sendKeyAndWait(this.browser, 't');
@@ -187,7 +187,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test('Tabbing back from workspace should reopen the flyout', async function () {
+  test.skip('Tabbing back from workspace should reopen the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
 
     await tabNavigateBackward(this.browser);
@@ -198,7 +198,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isTrue(flyoutIsOpen);
   });
 
-  test('Navigation position in workspace should be retained when tabbing to flyout and back', async function () {
+  test.skip('Navigation position in workspace should be retained when tabbing to flyout and back', async function () {
     // Navigate to the workspace and select a non-default block.
     await tabNavigateToWorkspace(this.browser);
 
@@ -214,7 +214,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.strictEqual(blockId, 'p5_draw_1');
   });
 
-  test('Clicking outside Blockly with focused toolbox closes the flyout', async function () {
+  test.skip('Clicking outside Blockly with focused toolbox closes the flyout', async function () {
     // Two tabs should navigate to the toolbox. One click to unfocus.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -227,7 +227,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test('Clicking outside Blockly with focused flyout closes the flyout', async function () {
+  test.skip('Clicking outside Blockly with focused flyout closes the flyout', async function () {
     // Two tabs should navigate to the toolbox. One key to select the flyout.
     await tabNavigateForward(this.browser);
     await tabNavigateForward(this.browser);
@@ -242,7 +242,7 @@ suite.only('Toolbox and flyout test', function () {
     chai.assert.isFalse(flyoutIsOpen);
   });
 
-  test('Clicking on toolbox category focuses it and opens flyout', async function () {
+  test.skip('Clicking on toolbox category focuses it and opens flyout', async function () {
     const elemId = await findToolboxCategoryIdByName(this.browser, 'Loops');
     const elem = this.browser.$(`#${elemId}`);
     await elem.click();

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -311,7 +311,7 @@ suite.only('Toolbox and flyout test', function () {
       await this.browser.getAlertText();
     });
 
-    test('callbackKey is activated with enter', async function () {
+    test.skip('callbackKey is activated with enter', async function () {
       setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
       await idle(this.browser);

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -21,7 +21,7 @@ import {
   getCurrentFocusedBlockId,
   tabNavigateToToolbox,
   checkForFailures,
-  idle,
+  pause,
   setSynchronizeCoreBlocklyRendering,
 } from './test_setup.js';
 
@@ -32,11 +32,15 @@ suite('Toolbox and flyout test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Tab navigating to toolbox should open flyout', async function () {
@@ -151,7 +155,7 @@ suite('Toolbox and flyout test', function () {
 
   test('Tabbing to the workspace should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await idle(this.browser);
+    await pause(this.browser);
 
     // The flyout should be closed since it lost focus.
     const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
@@ -300,7 +304,7 @@ suite('Toolbox and flyout test', function () {
     test('callbackkey is activated with enter', async function () {
       setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
-      await idle(this.browser);
+      await pause(this.browser);
 
       // First thing in the toolbox is the first button
       // Press Enter to activate it.
@@ -314,7 +318,7 @@ suite('Toolbox and flyout test', function () {
     test('callbackKey is activated with enter', async function () {
       setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
-      await idle(this.browser);
+      await pause(this.browser);
 
       // Navigate to second button.
       // Press Enter to activate it.

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -22,6 +22,7 @@ import {
   tabNavigateToToolbox,
   checkForFailures,
   idle,
+  setSynchronizeCoreBlocklyRendering,
 } from './test_setup.js';
 
 suite('Toolbox and flyout test', function () {
@@ -297,6 +298,7 @@ suite('Toolbox and flyout test', function () {
       }
     });
     test('callbackkey is activated with enter', async function () {
+      setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
       await idle(this.browser);
 
@@ -310,6 +312,7 @@ suite('Toolbox and flyout test', function () {
     });
 
     test('callbackKey is activated with enter', async function () {
+      setSynchronizeCoreBlocklyRendering(false);
       await tabNavigateToToolbox(this.browser);
       await idle(this.browser);
 

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -20,6 +20,7 @@ import {
   getCurrentFocusNodeId,
   getCurrentFocusedBlockId,
   tabNavigateToToolbox,
+  checkForFailures,
 } from './test_setup.js';
 
 suite('Toolbox and flyout test', function () {
@@ -30,6 +31,10 @@ suite('Toolbox and flyout test', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Tab navigating to toolbox should open flyout', async function () {

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -305,7 +305,7 @@ suite.only('Toolbox and flyout test', function () {
       // First thing in the toolbox is the first button
       // Press Enter to activate it.
       await keyRight(this.browser);
-      await sendKeyAndWait(this.browser, webdriverio.Key.Enter);
+      // await sendKeyAndWait(this.browser, webdriverio.Key.Enter);
 
       // This errors if there is no alert present
       // await this.browser.getAlertText();

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -21,6 +21,7 @@ import {
   getCurrentFocusedBlockId,
   tabNavigateToToolbox,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 
 suite('Toolbox and flyout test', function () {
@@ -30,7 +31,7 @@ suite('Toolbox and flyout test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -149,7 +150,7 @@ suite('Toolbox and flyout test', function () {
 
   test('Tabbing to the workspace should close the flyout', async function () {
     await tabNavigateToWorkspace(this.browser);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
 
     // The flyout should be closed since it lost focus.
     const flyoutIsOpen = await checkIfFlyoutIsOpen(this.browser);
@@ -297,7 +298,7 @@ suite('Toolbox and flyout test', function () {
     });
     test('callbackkey is activated with enter', async function () {
       await tabNavigateToToolbox(this.browser);
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
 
       // First thing in the toolbox is the first button
       // Press Enter to activate it.
@@ -310,7 +311,7 @@ suite('Toolbox and flyout test', function () {
 
     test('callbackKey is activated with enter', async function () {
       await tabNavigateToToolbox(this.browser);
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
 
       // Navigate to second button.
       // Press Enter to activate it.

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -38,7 +38,7 @@ suite('Toolbox and flyout test', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/flyout_test.ts
+++ b/test/webdriverio/test/flyout_test.ts
@@ -25,7 +25,7 @@ import {
   setSynchronizeCoreBlocklyRendering,
 } from './test_setup.js';
 
-suite.only('Toolbox and flyout test', function () {
+suite('Toolbox and flyout test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -23,6 +23,7 @@ import {
   keyUp,
   tabNavigateToToolbox,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 
 suite('Insert test', function () {
@@ -32,7 +33,7 @@ suite('Insert test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -150,7 +151,7 @@ suite('Insert test with more blocks', function () {
       testFileLocations.MORE_BLOCKS,
       this.timeout(),
     );
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -26,7 +26,7 @@ import {
   idle,
 } from './test_setup.js';
 
-suite.only('Insert test', function () {
+suite('Insert test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 
@@ -141,7 +141,7 @@ suite.only('Insert test', function () {
   });
 });
 
-suite.only('Insert test with more blocks', function () {
+suite('Insert test with more blocks', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -39,7 +39,7 @@ suite('Insert test', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });
@@ -161,7 +161,7 @@ suite('Insert test with more blocks', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -23,7 +23,7 @@ import {
   keyUp,
   tabNavigateToToolbox,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 
 suite('Insert test', function () {
@@ -33,11 +33,15 @@ suite('Insert test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Insert and cancel with block selection', async function () {
@@ -151,11 +155,15 @@ suite('Insert test with more blocks', function () {
       testFileLocations.MORE_BLOCKS,
       this.timeout(),
     );
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Does not bump immovable input blocks on insert', async function () {

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -26,7 +26,7 @@ import {
   idle,
 } from './test_setup.js';
 
-suite('Insert test', function () {
+suite.only('Insert test', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 
@@ -141,7 +141,7 @@ suite('Insert test', function () {
   });
 });
 
-suite('Insert test with more blocks', function () {
+suite.only('Insert test with more blocks', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 

--- a/test/webdriverio/test/insert_test.ts
+++ b/test/webdriverio/test/insert_test.ts
@@ -22,6 +22,7 @@ import {
   blockIsPresent,
   keyUp,
   tabNavigateToToolbox,
+  checkForFailures,
 } from './test_setup.js';
 
 suite('Insert test', function () {
@@ -32,6 +33,10 @@ suite('Insert test', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Insert and cancel with block selection', async function () {
@@ -146,6 +151,10 @@ suite('Insert test with more blocks', function () {
       this.timeout(),
     );
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Does not bump immovable input blocks on insert', async function () {

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -26,7 +26,7 @@ const isKeyboardNavigating = function (browser: WebdriverIO.Browser) {
   });
 };
 
-suite(
+suite.only(
   'Keyboard navigation mode set on mouse or keyboard interaction',
   function () {
     // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -53,7 +53,7 @@ suite(
     teardown(async function () {
       await checkForFailures(
         this.browser,
-        this.currentTest!.title,
+        this.currentTest?.title,
         this.currentTest?.state,
       );
     });

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -16,6 +16,7 @@ import {
   clickBlock,
   sendKeyAndWait,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -38,7 +39,7 @@ suite(
         this.timeout(),
       );
 
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
 
       // Reset the keyboard navigation state between tests.
       await this.browser.execute(() => {
@@ -54,7 +55,7 @@ suite(
     });
 
     test('T to open toolbox enables keyboard mode', async function () {
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, 't');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -62,14 +63,14 @@ suite(
 
     test('M for move mode enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, 'm');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
 
     test('W for workspace cursor enables keyboard mode', async function () {
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, 'w');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -77,7 +78,7 @@ suite(
 
     test('X to disconnect enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, 'x');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -86,7 +87,7 @@ suite(
     test('Copy does not change keyboard mode state', async function () {
       // Make sure we're on a copyable block so that copy occurs
       await focusOnBlock(this.browser, 'controls_if_2');
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
@@ -95,7 +96,7 @@ suite(
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -104,7 +105,7 @@ suite(
     test('Delete does not change keyboard mode state', async function () {
       // Make sure we're on a deletable block so that delete occurs
       await focusOnBlock(this.browser, 'controls_if_2');
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
@@ -115,7 +116,7 @@ suite(
 
       // Focus a different deletable block
       await focusOnBlock(this.browser, 'controls_if_1');
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -126,10 +127,10 @@ suite(
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       // Right click a block
       await clickBlock(this.browser, 'controls_if_1', {button: 'right'});
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
     });
@@ -139,7 +140,7 @@ suite(
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       // Drag a block
       const element = await getBlockElementById(this.browser, 'controls_if_1');
 
@@ -152,7 +153,7 @@ suite(
         );
       });
       await element.dragAndDrop({x: 10, y: 10});
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
     });

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -16,7 +16,7 @@ import {
   clickBlock,
   sendKeyAndWait,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -39,7 +39,7 @@ suite(
         this.timeout(),
       );
 
-      await idle(this.browser);
+      await pause(this.browser);
 
       // Reset the keyboard navigation state between tests.
       await this.browser.execute(() => {
@@ -50,12 +50,16 @@ suite(
       await tabNavigateToWorkspace(this.browser);
     });
 
-    teardown(async function() {
-      await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+    teardown(async function () {
+      await checkForFailures(
+        this.browser,
+        this.currentTest!.title,
+        this.currentTest?.state,
+      );
     });
 
     test('T to open toolbox enables keyboard mode', async function () {
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, 't');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -63,14 +67,14 @@ suite(
 
     test('M for move mode enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, 'm');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
     });
 
     test('W for workspace cursor enables keyboard mode', async function () {
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, 'w');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -78,7 +82,7 @@ suite(
 
     test('X to disconnect enables keyboard mode', async function () {
       await focusOnBlock(this.browser, 'controls_if_2');
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, 'x');
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -87,7 +91,7 @@ suite(
     test('Copy does not change keyboard mode state', async function () {
       // Make sure we're on a copyable block so that copy occurs
       await focusOnBlock(this.browser, 'controls_if_2');
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
@@ -96,7 +100,7 @@ suite(
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, [Key.Ctrl, 'c']);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -105,7 +109,7 @@ suite(
     test('Delete does not change keyboard mode state', async function () {
       // Make sure we're on a deletable block so that delete occurs
       await focusOnBlock(this.browser, 'controls_if_2');
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
@@ -116,7 +120,7 @@ suite(
 
       // Focus a different deletable block
       await focusOnBlock(this.browser, 'controls_if_1');
-      await idle(this.browser);
+      await pause(this.browser);
       await sendKeyAndWait(this.browser, Key.Backspace);
 
       chai.assert.isTrue(await isKeyboardNavigating(this.browser));
@@ -127,10 +131,10 @@ suite(
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
-      await idle(this.browser);
+      await pause(this.browser);
       // Right click a block
       await clickBlock(this.browser, 'controls_if_1', {button: 'right'});
-      await idle(this.browser);
+      await pause(this.browser);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
     });
@@ -140,7 +144,7 @@ suite(
         Blockly.keyboardNavigationController.setIsActive(true);
       });
 
-      await idle(this.browser);
+      await pause(this.browser);
       // Drag a block
       const element = await getBlockElementById(this.browser, 'controls_if_1');
 
@@ -153,7 +157,7 @@ suite(
         );
       });
       await element.dragAndDrop({x: 10, y: 10});
-      await idle(this.browser);
+      await pause(this.browser);
 
       chai.assert.isFalse(await isKeyboardNavigating(this.browser));
     });

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -15,6 +15,7 @@ import {
   tabNavigateToWorkspace,
   clickBlock,
   sendKeyAndWait,
+  checkForFailures,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -46,6 +47,10 @@ suite(
 
       // Start with the workspace focused.
       await tabNavigateToWorkspace(this.browser);
+    });
+
+    teardown(async function() {
+      await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
     });
 
     test('T to open toolbox enables keyboard mode', async function () {

--- a/test/webdriverio/test/keyboard_mode_test.ts
+++ b/test/webdriverio/test/keyboard_mode_test.ts
@@ -26,7 +26,7 @@ const isKeyboardNavigating = function (browser: WebdriverIO.Browser) {
   });
 };
 
-suite.only(
+suite(
   'Keyboard navigation mode set on mouse or keyboard interaction',
   function () {
     // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -20,7 +20,7 @@ import {
   idle,
 } from './test_setup.js';
 
-suite.only('Move start tests', function () {
+suite('Move start tests', function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);
@@ -46,7 +46,7 @@ suite.only('Move start tests', function () {
   //
   // Also tests initating a move using the shortcut key.
   test('Start moving statement blocks', async function () {
-    for (let i = 1; i < 2; i++) {
+    for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `statement_${i}`);
 
@@ -110,7 +110,7 @@ suite.only('Move start tests', function () {
   //
   // Also tests initiating a move via the context menu.
   test('Start moving value blocks', async function () {
-    for (let i = 1; i < 2; i++) {
+    for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `value_${i}`);
 

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -21,9 +21,9 @@ import {
 } from './test_setup.js';
 
 suite('Move start tests', function () {
-  // Increase timeout to 10s for this longer test (but disable
-  // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
-  this.timeout(PAUSE_TIME ? 0 : 10000);
+  // Increase timeout for this longer test (but disable timeouts if when
+  // non-zero PAUSE_TIME is used to watch tests) run.
+  this.timeout(PAUSE_TIME ? 0 : 30000);
 
   // Clear the workspace and load start blocks.
   setup(async function () {
@@ -187,9 +187,9 @@ suite('Move start tests', function () {
 });
 
 suite('Statement move tests', function () {
-  // Increase timeout to 10s for this longer test (but disable
-  // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
-  this.timeout(PAUSE_TIME ? 0 : 10000);
+  // Increase timeout for this longer test (but disable timeouts if when
+  // non-zero PAUSE_TIME is used to watch tests) run.
+  this.timeout(PAUSE_TIME ? 0 : 30000);
 
   // Clear the workspace and load start blocks.
   setup(async function () {
@@ -372,9 +372,9 @@ suite('Statement move tests', function () {
 });
 
 suite(`Value expression move tests`, function () {
-  // Increase timeout to 10s for this longer test (but disable
-  // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
-  this.timeout(PAUSE_TIME ? 0 : 10000);
+  // Increase timeout for this longer test (but disable timeouts if when
+  // non-zero PAUSE_TIME is used to watch tests) run.
+  this.timeout(PAUSE_TIME ? 0 : 30000);
 
   /** Serialized simple reporter value block with no inputs. */
   const VALUE_SIMPLE = {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -186,7 +186,7 @@ suite.only('Move start tests', function () {
   });
 });
 
-suite.only('Statement move tests', function () {
+suite('Statement move tests', function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);
@@ -371,7 +371,7 @@ suite.only('Statement move tests', function () {
   });
 });
 
-suite.only(`Value expression move tests`, function () {
+suite(`Value expression move tests`, function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -17,7 +17,7 @@ import {
   keyDown,
   contextMenuItems,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 
 suite('Move start tests', function () {
@@ -31,11 +31,15 @@ suite('Move start tests', function () {
       testFileLocations.MOVE_START_TEST_BLOCKS,
       this.timeout(),
     );
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   // When a move of a statement block begins, it is expected that only
@@ -197,11 +201,15 @@ suite('Statement move tests', function () {
       testFileLocations.MOVE_STATEMENT_TEST_BLOCKS,
       this.timeout(),
     );
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   /** Serialized simple statement block with no statement inputs. */
@@ -484,11 +492,15 @@ suite(`Value expression move tests`, function () {
           ),
           this.timeout(),
         );
-        await idle(this.browser);
+        await pause(this.browser);
       });
 
-      teardown(async function() {
-        await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+      teardown(async function () {
+        await checkForFailures(
+          this.browser,
+          this.currentTest!.title,
+          this.currentTest?.state,
+        );
       });
 
       suite('Constrained moves of a simple reporter block', function () {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -45,7 +45,7 @@ suite.only('Move start tests', function () {
   // heal will occur.
   //
   // Also tests initating a move using the shortcut key.
-  test.only('Start moving statement blocks', async function () {
+  test('Start moving statement blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `statement_${i}`);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -18,7 +18,7 @@ import {
   contextMenuItems,
 } from './test_setup.js';
 
-suite('Move start tests', function () {
+suite.skip('Move start tests', function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -46,7 +46,7 @@ suite.only('Move start tests', function () {
   //
   // Also tests initating a move using the shortcut key.
   test('Start moving statement blocks', async function () {
-    for (let i = 1; i < 7; i++) {
+    for (let i = 1; i < 2; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `statement_${i}`);
 

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -20,7 +20,7 @@ import {
   idle,
 } from './test_setup.js';
 
-suite.skip('Move start tests', function () {
+suite('Move start tests', function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -110,7 +110,7 @@ suite.only('Move start tests', function () {
   //
   // Also tests initiating a move via the context menu.
   test('Start moving value blocks', async function () {
-    for (let i = 1; i < 7; i++) {
+    for (let i = 1; i < 2; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `value_${i}`);
 

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -109,7 +109,7 @@ suite('Move start tests', function () {
   // a stack heal (really: unary operator chain heal) will NOT occur.
   //
   // Also tests initiating a move via the context menu.
-  test('Start moving value blocks', async function () {
+  test.only('Start moving value blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `value_${i}`);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -20,7 +20,7 @@ import {
   idle,
 } from './test_setup.js';
 
-suite('Move start tests', function () {
+suite.only('Move start tests', function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);
@@ -109,7 +109,7 @@ suite('Move start tests', function () {
   // a stack heal (really: unary operator chain heal) will NOT occur.
   //
   // Also tests initiating a move via the context menu.
-  test.only('Start moving value blocks', async function () {
+  test('Start moving value blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `value_${i}`);
@@ -186,7 +186,7 @@ suite('Move start tests', function () {
   });
 });
 
-suite('Statement move tests', function () {
+suite.only('Statement move tests', function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);
@@ -371,7 +371,7 @@ suite('Statement move tests', function () {
   });
 });
 
-suite(`Value expression move tests`, function () {
+suite.only(`Value expression move tests`, function () {
   // Increase timeout to 10s for this longer test (but disable
   // timeouts if when non-zero PAUSE_TIME is used to watch tests) run.
   this.timeout(PAUSE_TIME ? 0 : 10000);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -16,6 +16,7 @@ import {
   sendKeyAndWait,
   keyDown,
   contextMenuItems,
+  checkForFailures,
 } from './test_setup.js';
 
 suite.skip('Move start tests', function () {
@@ -30,6 +31,10 @@ suite.skip('Move start tests', function () {
       this.timeout(),
     );
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   // When a move of a statement block begins, it is expected that only
@@ -192,6 +197,10 @@ suite('Statement move tests', function () {
       this.timeout(),
     );
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   /** Serialized simple statement block with no statement inputs. */
@@ -475,6 +484,10 @@ suite(`Value expression move tests`, function () {
           this.timeout(),
         );
         await this.browser.pause(PAUSE_TIME);
+      });
+
+      teardown(async function() {
+        await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
       });
 
       suite('Constrained moves of a simple reporter block', function () {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -17,6 +17,7 @@ import {
   keyDown,
   contextMenuItems,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 
 suite.skip('Move start tests', function () {
@@ -30,7 +31,7 @@ suite.skip('Move start tests', function () {
       testFileLocations.MOVE_START_TEST_BLOCKS,
       this.timeout(),
     );
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -196,7 +197,7 @@ suite('Statement move tests', function () {
       testFileLocations.MOVE_STATEMENT_TEST_BLOCKS,
       this.timeout(),
     );
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {
@@ -483,7 +484,7 @@ suite(`Value expression move tests`, function () {
           ),
           this.timeout(),
         );
-        await this.browser.pause(PAUSE_TIME);
+        await idle(this.browser);
       });
 
       teardown(async function() {

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -45,7 +45,7 @@ suite.only('Move start tests', function () {
   // heal will occur.
   //
   // Also tests initating a move using the shortcut key.
-  test('Start moving statement blocks', async function () {
+  test.only('Start moving statement blocks', async function () {
     for (let i = 1; i < 7; i++) {
       // Navigate to statement_<i>.
       await focusOnBlock(this.browser, `statement_${i}`);

--- a/test/webdriverio/test/move_test.ts
+++ b/test/webdriverio/test/move_test.ts
@@ -37,7 +37,7 @@ suite('Move start tests', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });
@@ -207,7 +207,7 @@ suite('Statement move tests', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });
@@ -498,7 +498,7 @@ suite(`Value expression move tests`, function () {
       teardown(async function () {
         await checkForFailures(
           this.browser,
-          this.currentTest!.title,
+          this.currentTest?.title,
           this.currentTest?.state,
         );
       });

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -17,6 +17,7 @@ import {
   sendKeyAndWait,
   keyRight,
   keyDown,
+  checkForFailures,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -38,6 +39,10 @@ suite('Mutator navigation', function () {
       // Activate the icon
       await sendKeyAndWait(this.browser, Key.Enter);
     };
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Enter opens mutator', async function () {

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -18,6 +18,7 @@ import {
   keyRight,
   keyDown,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -33,7 +34,7 @@ suite('Mutator navigation', function () {
     );
     this.openMutator = async () => {
       await focusOnBlock(this.browser, 'controls_if_1');
-      await this.browser.pause(PAUSE_TIME);
+      await idle(this.browser);
       // Navigate to the mutator icon
       await keyRight(this.browser);
       // Activate the icon
@@ -101,7 +102,7 @@ suite('Mutator navigation', function () {
     await sendKeyAndWait(this.browser, 't');
     // Navigate down to the second block in the flyout
     await keyDown(this.browser);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     // Hit enter to enter insert mode
     await sendKeyAndWait(this.browser, Key.Enter);
     // Hit enter again to lock it into place on the connection

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -18,7 +18,7 @@ import {
   keyRight,
   keyDown,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -34,7 +34,7 @@ suite('Mutator navigation', function () {
     );
     this.openMutator = async () => {
       await focusOnBlock(this.browser, 'controls_if_1');
-      await idle(this.browser);
+      await pause(this.browser);
       // Navigate to the mutator icon
       await keyRight(this.browser);
       // Activate the icon
@@ -42,8 +42,12 @@ suite('Mutator navigation', function () {
     };
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Enter opens mutator', async function () {
@@ -102,7 +106,7 @@ suite('Mutator navigation', function () {
     await sendKeyAndWait(this.browser, 't');
     // Navigate down to the second block in the flyout
     await keyDown(this.browser);
-    await idle(this.browser);
+    await pause(this.browser);
     // Hit enter to enter insert mode
     await sendKeyAndWait(this.browser, Key.Enter);
     // Hit enter again to lock it into place on the connection

--- a/test/webdriverio/test/mutator_test.ts
+++ b/test/webdriverio/test/mutator_test.ts
@@ -45,7 +45,7 @@ suite('Mutator navigation', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -44,7 +44,7 @@ suite('Scrolling into view', function () {
     await testSetup(testFileLocations.BASE, this.timeout());
   });
 
-  test('Insert scrolls new block into view', async function () {
+  test.only('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 
@@ -72,6 +72,27 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);
+    const blockBounds = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      const block = workspace.getBlocksByType(
+        'controls_if',
+      )[0] as Blockly.BlockSvg;
+      const blockBounds = block.getBoundingRectangleWithoutChildren();
+      return blockBounds;
+    });
+    console.log("block bounds:", blockBounds);
+    const viewport = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
+      const viewport = new Blockly.utils.Rect(
+        rawViewport.top,
+        rawViewport.top + rawViewport.height,
+        rawViewport.left,
+        rawViewport.left + rawViewport.width,
+      );
+      return viewport;
+    });
+    console.log("viewport:", viewport);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -201,7 +201,7 @@ suite('Scrolling into view', function () {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       return workspace.getBlocksByType(
         'controls_if',
-      ).map((block) => { (block as Blockly.BlockSvg).id });
+      ).map((block) => { return (block as Blockly.BlockSvg).getFocusableElement().id });
     });
     console.log('matched blocks to controls_if:', matchedBlocks);
     const inViewport = await this.browser.execute(() => {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -59,7 +59,6 @@ suite('Scrolling into view', function () {
     // Increase timeout for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 30000);
 
-    // setPauseTime(0);
     await tabNavigateToWorkspace(this.browser);
 
     // Separate the two top-level blocks by moving p5_draw_1 further down.
@@ -82,6 +81,7 @@ suite('Scrolling into view', function () {
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
+    await sendKeyAndWait(this.browser, Key.Enter, 2);
 
     // Assert new block has been scrolled into the viewport.
     await pause(this.browser);

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -30,11 +30,20 @@ suite('Scrolling into view', function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     // Note that a viewport is used here over adjusting window size to ensure
     // consistency across platforms and environments.
-    await this.browser.setViewport({
-      width: 800, height: 600, devicePixelRatio: 1
-    });
+    // await this.browser.setViewport({
+      // width: 800, height: 600, devicePixelRatio: 1
+    // });
+    this.windowSize = await this.browser.getWindowSize();
+    await this.browser.setWindowSize(800, 600);
     await this.browser.pause(PAUSE_TIME);
   });
+
+  // Restore original browser window size.
+  suiteTeardown(async function () {
+  await this.browser.setWindowSize(
+    this.windowSize.width,
+    this.windowSize.height,
+  );
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -84,6 +84,11 @@ suite('Scrolling into view', function () {
       return Blockly.getFocusManager().getFocusedNode()?.getFocusableElement()?.id;
     });
     console.log("current focused node after insert:", focusedNodeId2);
+    const scrollPosition3 = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      return [workspace.scrollX, workspace.scrollY];
+    });
+    console.log("workspace scroll position after insert:", scrollPosition3);
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -116,7 +116,7 @@ suite('Scrolling into view', function () {
     console.log("workspace scroll position after insert:", scrollPosition3);
 
     // Assert new block has been scrolled into the viewport.
-    await this.browser.pause(5000);
+    await this.browser.pause(PAUSE_TIME);
     await this.browser.saveScreenshot(`failures/extra_snapshot_for_verification.png`);
     const blockBounds = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -112,8 +112,8 @@ suite('Scrolling into view', function () {
       const block = workspace.getBlocksByType(
         'controls_if',
       )[0] as Blockly.BlockSvg;
-      const blockBounds = block.getParent()?.getBoundingRectangleWithoutChildren();
-      return [blockBounds, block.getParent()?.getFocusableElement()?.id];
+      const blockBounds = block.getSurroundParent()?.getBoundingRectangleWithoutChildren();
+      return [blockBounds, block.getSurroundParent()?.getFocusableElement()?.id];
     });
     console.log("block's parent bounds:", blockParentBounds, "id:", blockParentId);
     const viewport = await this.browser.execute(() => {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -57,7 +57,7 @@ suite('Scrolling into view', function () {
     await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
-  test.only('Insert scrolls new block into view', async function () {
+  test('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -17,6 +17,7 @@ import {
   testFileLocations,
   testSetup,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 
 suite('Scrolling into view', function () {
@@ -35,7 +36,7 @@ suite('Scrolling into view', function () {
     // });
     this.windowSize = await this.browser.getWindowSize();
     await this.browser.setWindowSize(800, 600);
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   // Restore original browser window size.
@@ -87,7 +88,7 @@ suite('Scrolling into view', function () {
       );
     });
     // Pause to allow scrolling to stabilize before proceeding.
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     const scrollPosition2 = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       return [workspace.scrollX, workspace.scrollY];
@@ -116,7 +117,7 @@ suite('Scrolling into view', function () {
     console.log("workspace scroll position after insert:", scrollPosition3);
 
     // Assert new block has been scrolled into the viewport.
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
     // await this.browser.saveScreenshot(`failures/extra_snapshot_for_verification.png`);
     const blockBounds = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -71,11 +71,19 @@ suite('Scrolling into view', function () {
       return [workspace.scrollX, workspace.scrollY];
     });
     console.log("workspace scroll position after scroll:", scrollPosition2);
+    const focusedNodeId1 = await this.browser.execute(() => {
+      return Blockly.getFocusManager().getFocusedNode()?.getFocusableElement()?.id;
+    });
+    console.log("current focused node before insert:", focusedNodeId1);
 
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter, 2);
+    const focusedNodeId2 = await this.browser.execute(() => {
+      return Blockly.getFocusManager().getFocusedNode()?.getFocusableElement()?.id;
+    });
+    console.log("current focused node after insert:", focusedNodeId2);
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -39,7 +39,7 @@ suite('Scrolling into view', function () {
     await testSetup(testFileLocations.BASE, this.timeout());
   });
 
-  test('Insert scrolls new block into view', async function () {
+  test.only('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 
@@ -67,6 +67,27 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);
+    const blockBounds = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      const block = workspace.getBlocksByType(
+        'controls_if',
+      )[0] as Blockly.BlockSvg;
+      const blockBounds = block.getBoundingRectangleWithoutChildren();
+      return blockBounds;
+    });
+    console.log("block bounds:", blockBounds);
+    const viewport = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
+      const viewport = new Blockly.utils.Rect(
+        rawViewport.top,
+        rawViewport.top + rawViewport.height,
+        rawViewport.left,
+        rawViewport.left + rawViewport.width,
+      );
+      return viewport;
+    });
+    console.log("viewport:", viewport);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -117,7 +117,11 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.saveScreenshot(`failures/extra_snapshot_for_verification.png`);
+    await this.browser.execute(async () => {
+      await Blockly.renderManagement.finishQueuedRenders()
+    });
+    await this.browser.pause(3000);
+    // await this.browser.saveScreenshot(`failures/extra_snapshot_for_verification.png`);
     const blockBounds = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -16,6 +16,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  checkForFailures,
 } from './test_setup.js';
 
 suite('Scrolling into view', function () {
@@ -38,6 +39,10 @@ suite('Scrolling into view', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     await testSetup(testFileLocations.BASE, this.timeout());
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Insert scrolls new block into view', async function () {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -197,6 +197,13 @@ suite('Scrolling into view', function () {
       return viewport;
     });
     console.log("viewport:", viewport);
+    const matchedBlocks = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      return workspace.getBlocksByType(
+        'controls_if',
+      ).map((block) => { (block as Blockly.BlockSvg).id });
+    });
+    console.log('matched blocks to controls_if:', matchedBlocks);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -26,17 +26,17 @@ suite('Scrolling into view', function () {
   // N.B. that this is called only one per suite, not once per test.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    this.windowSize = await this.browser.getWindowSize();
-    await this.browser.setWindowSize(800, 600);
+    // this.windowSize = await this.browser.getWindowSize();
+    await this.browser.setViewport({width: 800, height: 600, devicePixelRatio: 1});
     await this.browser.pause(PAUSE_TIME);
   });
 
   // Restore original browser window size.
   suiteTeardown(async function () {
-    await this.browser.setWindowSize(
-      this.windowSize.width,
-      this.windowSize.height,
-    );
+    // await this.browser.setWindowSize(
+    //   this.windowSize.width,
+    //   this.windowSize.height,
+    // );
   });
 
   // Clear the workspace and load start blocks.

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -117,10 +117,6 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);
-    await this.browser.execute(async () => {
-      await Blockly.renderManagement.finishQueuedRenders()
-    });
-    await this.browser.pause(3000);
     // await this.browser.saveScreenshot(`failures/extra_snapshot_for_verification.png`);
     const blockBounds = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -126,7 +126,7 @@ suite('Scrolling into view', function () {
       return blockBounds;
     });
     console.log("block bounds:", blockBounds);
-    const [blockPosition, blockRelative] = await this.browser.execute(() => {
+    const [blockPosition, blockRelative, x, y, transform, style] = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(
         'controls_if',
@@ -173,9 +173,9 @@ suite('Scrolling into view', function () {
           }
         }
       }
-      return [block.getRelativeToSurfaceXY(), xy];
+      return [block.getRelativeToSurfaceXY(), xy, x, y, transform, style];
     });
-    console.log("block position:", blockPosition, "relative:", blockRelative);
+    console.log("block position:", blockPosition, "relative:", blockRelative, x, y, transform, style);
     const [blockParentBounds, blockParentId] = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -116,7 +116,7 @@ suite('Scrolling into view', function () {
     console.log("workspace scroll position after insert:", scrollPosition3);
 
     // Assert new block has been scrolled into the viewport.
-    await this.browser.pause(PAUSE_TIME);
+    await this.browser.pause(5000);
     const blockBounds = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -51,6 +51,11 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
     // Scroll back up, leaving cursor on the draw block out of the viewport.
+    const scrollPosition1 = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      return [workspace.scrollX, workspace.scrollY];
+    });
+    console.log("workspace scroll position before scroll:", scrollPosition1);
     await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       workspace.scrollBoundsIntoView(
@@ -59,6 +64,11 @@ suite('Scrolling into view', function () {
         ).getBoundingRectangleWithoutChildren(),
       );
     });
+    const scrollPosition2 = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      return [workspace.scrollX, workspace.scrollY];
+    });
+    console.log("workspace scroll position after scroll:", scrollPosition2);
 
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -77,27 +77,27 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);
-    const blockBounds = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const block = workspace.getBlocksByType(
-        'controls_if',
-      )[0] as Blockly.BlockSvg;
-      const blockBounds = block.getBoundingRectangleWithoutChildren();
-      return blockBounds;
-    });
-    console.log("block bounds:", blockBounds);
-    const viewport = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
-      const viewport = new Blockly.utils.Rect(
-        rawViewport.top,
-        rawViewport.top + rawViewport.height,
-        rawViewport.left,
-        rawViewport.left + rawViewport.width,
-      );
-      return viewport;
-    });
-    console.log("viewport:", viewport);
+    // const blockBounds = await this.browser.execute(() => {
+    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    //   const block = workspace.getBlocksByType(
+    //     'controls_if',
+    //   )[0] as Blockly.BlockSvg;
+    //   const blockBounds = block.getBoundingRectangleWithoutChildren();
+    //   return blockBounds;
+    // });
+    // console.log("block bounds:", blockBounds);
+    // const viewport = await this.browser.execute(() => {
+    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    //   const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
+    //   const viewport = new Blockly.utils.Rect(
+    //     rawViewport.top,
+    //     rawViewport.top + rawViewport.height,
+    //     rawViewport.left,
+    //     rawViewport.left + rawViewport.width,
+    //   );
+    //   return viewport;
+    // });
+    // console.log("viewport:", viewport);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -39,7 +39,7 @@ suite('Scrolling into view', function () {
     await testSetup(testFileLocations.BASE, this.timeout());
   });
 
-  test('Insert scrolls new block into view', async function () {
+  test.only('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -40,10 +40,11 @@ suite('Scrolling into view', function () {
 
   // Restore original browser window size.
   suiteTeardown(async function () {
-  await this.browser.setWindowSize(
-    this.windowSize.width,
-    this.windowSize.height,
-  );
+    await this.browser.setWindowSize(
+      this.windowSize.width,
+      this.windowSize.height,
+    );
+  });
 
   // Clear the workspace and load start blocks.
   setup(async function () {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -9,6 +9,7 @@ import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
   sendKeyAndWait,
+  keyUp,
   keyDown,
   keyRight,
   PAUSE_TIME,
@@ -85,7 +86,10 @@ suite('Scrolling into view', function () {
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await sendKeyAndWait(this.browser, Key.Enter, 2);
+    await sendKeyAndWait(this.browser, Key.Enter);
+    await keyDown(this.browser);
+    await keyUp(this.browser);
+    await sendKeyAndWait(this.browser, Key.Enter);
     const focusedNodeId2 = await this.browser.execute(() => {
       return Blockly.getFocusManager().getFocusedNode()?.getFocusableElement()?.id;
     });

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -17,26 +17,21 @@ import {
   testFileLocations,
   testSetup,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 
 suite('Scrolling into view', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 
-  // Resize browser to provide predictable small viewport size for scrolling.
+  // Resize browser to provide predictable small window size for scrolling.
   //
   // N.B. that this is called only one per suite, not once per test.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    // Note that a viewport is used here over adjusting window size to ensure
-    // consistency across platforms and environments.
-    // await this.browser.setViewport({
-      // width: 800, height: 600, devicePixelRatio: 1
-    // });
     this.windowSize = await this.browser.getWindowSize();
     await this.browser.setWindowSize(800, 600);
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
   // Restore original browser window size.
@@ -52,8 +47,12 @@ suite('Scrolling into view', function () {
     await testSetup(testFileLocations.BASE, this.timeout());
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Insert scrolls new block into view', async function () {
@@ -78,18 +77,14 @@ suite('Scrolling into view', function () {
       );
     });
     // Pause to allow scrolling to stabilize before proceeding.
-    await idle(this.browser);
+    await pause(this.browser);
 
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');
     await keyRight(this.browser);
-    await sendKeyAndWait(this.browser, Key.Enter);
-    await keyDown(this.browser);
-    await keyUp(this.browser);
-    await sendKeyAndWait(this.browser, Key.Enter);
 
     // Assert new block has been scrolled into the viewport.
-    await idle(this.browser);
+    await pause(this.browser);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -116,6 +116,14 @@ suite('Scrolling into view', function () {
       return blockBounds;
     });
     console.log("block bounds:", blockBounds);
+    const blockPosition = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      const block = workspace.getBlocksByType(
+        'controls_if',
+      )[0] as Blockly.BlockSvg;
+      return block.getRelativeToSurfaceXY();
+    });
+    console.log("block position:", blockPosition);
     const [blockParentBounds, blockParentId] = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -57,8 +57,8 @@ suite('Scrolling into view', function () {
   });
 
   test('Insert scrolls new block into view', async function () {
-    // Increase timeout to 10s for this longer test.
-    this.timeout(PAUSE_TIME ? 0 : 10000);
+    // Increase timeout for this longer test.
+    this.timeout(PAUSE_TIME ? 0 : 30000);
 
     // setPauseTime(0);
     await tabNavigateToWorkspace(this.browser);

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -51,11 +51,11 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
     // Scroll back up, leaving cursor on the draw block out of the viewport.
-    const scrollPosition1 = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      return [workspace.scrollX, workspace.scrollY];
-    });
-    console.log("workspace scroll position before scroll:", scrollPosition1);
+    // const scrollPosition1 = await this.browser.execute(() => {
+    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    //   return [workspace.scrollX, workspace.scrollY];
+    // });
+    // console.log("workspace scroll position before scroll:", scrollPosition1);
     await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       workspace.scrollBoundsIntoView(
@@ -64,11 +64,11 @@ suite('Scrolling into view', function () {
         ).getBoundingRectangleWithoutChildren(),
       );
     });
-    const scrollPosition2 = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      return [workspace.scrollX, workspace.scrollY];
-    });
-    console.log("workspace scroll position after scroll:", scrollPosition2);
+    // const scrollPosition2 = await this.browser.execute(() => {
+    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    //   return [workspace.scrollX, workspace.scrollY];
+    // });
+    // console.log("workspace scroll position after scroll:", scrollPosition2);
 
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -68,19 +68,7 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, 'm');
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
-    // setPauseTime(1000);
-    const movedBlockBounds = await this.browser.execute(() => {
-      const block = Blockly.getFocusManager().getFocusedNode() as Blockly.BlockSvg;
-      const blockBounds = block.getBoundingRectangleWithoutChildren();
-      return blockBounds;
-    });
-    console.log("just moved block bounds:", movedBlockBounds);
     // Scroll back up, leaving cursor on the draw block out of the viewport.
-    const scrollPosition1 = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      return [workspace.scrollX, workspace.scrollY];
-    });
-    console.log("workspace scroll position before scroll:", scrollPosition1);
     await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       workspace.scrollBoundsIntoView(
@@ -91,15 +79,6 @@ suite('Scrolling into view', function () {
     });
     // Pause to allow scrolling to stabilize before proceeding.
     await idle(this.browser);
-    const scrollPosition2 = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      return [workspace.scrollX, workspace.scrollY];
-    });
-    console.log("workspace scroll position after scroll:", scrollPosition2);
-    const focusedNodeId1 = await this.browser.execute(() => {
-      return Blockly.getFocusManager().getFocusedNode()?.getFocusableElement()?.id;
-    });
-    console.log("current focused node before insert:", focusedNodeId1);
 
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');
@@ -108,106 +87,9 @@ suite('Scrolling into view', function () {
     await keyDown(this.browser);
     await keyUp(this.browser);
     await sendKeyAndWait(this.browser, Key.Enter);
-    const focusedNodeId2 = await this.browser.execute(() => {
-      return Blockly.getFocusManager().getFocusedNode()?.getFocusableElement()?.id;
-    });
-    console.log("current focused node after insert:", focusedNodeId2);
-    const scrollPosition3 = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      return [workspace.scrollX, workspace.scrollY];
-    });
-    console.log("workspace scroll position after insert:", scrollPosition3);
 
     // Assert new block has been scrolled into the viewport.
     await idle(this.browser);
-    // await this.browser.saveScreenshot(`failures/extra_snapshot_for_verification.png`);
-    const blockBounds = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const block = workspace.getBlocksByType(
-        'controls_if',
-      )[0] as Blockly.BlockSvg;
-      const blockBounds = block.getBoundingRectangleWithoutChildren();
-      return blockBounds;
-    });
-    console.log("block bounds:", blockBounds);
-    const [blockPosition, blockRelative, x, y, transform, style] = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const block = workspace.getBlocksByType(
-        'controls_if',
-      )[0] as Blockly.BlockSvg;
-
-      const XY_REGEX = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
-      const XY_STYLE_REGEX =
-        /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
-      const element = block.getSvgRoot();
-      class Coordinate {
-        constructor(public x: number, public y: number){}
-      };
-      const xy = new Coordinate(0, 0);
-      // First, check for x and y attributes.
-      // Checking for the existence of x/y properties is faster than getAttribute.
-      // However, x/y contains an SVGAnimatedLength object, so rely on getAttribute
-      // to get the number.
-      const x = (element as any).x && element.getAttribute('x');
-      const y = (element as any).y && element.getAttribute('y');
-      if (x) {
-        xy.x = parseInt(x);
-      }
-      if (y) {
-        xy.y = parseInt(y);
-      }
-      // Second, check for transform="translate(...)" attribute.
-      const transform = element.getAttribute('transform');
-      const r = transform && transform.match(XY_REGEX);
-      if (r) {
-        xy.x += Number(r[1]);
-        if (r[3]) {
-          xy.y += Number(r[3]);
-        }
-      }
-
-      // Then check for style = transform: translate(...) or translate3d(...)
-      const style = element.getAttribute('style');
-      if (style && style.includes('translate')) {
-        const styleComponents = style.match(XY_STYLE_REGEX);
-        if (styleComponents) {
-          xy.x += Number(styleComponents[1]);
-          if (styleComponents[3]) {
-            xy.y += Number(styleComponents[3]);
-          }
-        }
-      }
-      return [block.getRelativeToSurfaceXY(), xy, x, y, transform, style];
-    });
-    console.log("block position:", blockPosition, "relative:", blockRelative, x, y, transform, style);
-    const [blockParentBounds, blockParentId] = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const block = workspace.getBlocksByType(
-        'controls_if',
-      )[0] as Blockly.BlockSvg;
-      const blockBounds = block.getSurroundParent()?.getBoundingRectangleWithoutChildren();
-      return [blockBounds, block.getSurroundParent()?.getFocusableElement()?.id];
-    });
-    console.log("block's parent bounds:", blockParentBounds, "id:", blockParentId);
-    const viewport = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
-      const viewport = new Blockly.utils.Rect(
-        rawViewport.top,
-        rawViewport.top + rawViewport.height,
-        rawViewport.left,
-        rawViewport.left + rawViewport.width,
-      );
-      return viewport;
-    });
-    console.log("viewport:", viewport);
-    const matchedBlocks = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      return workspace.getBlocksByType(
-        'controls_if',
-      ).map((block) => { return (block as Blockly.BlockSvg).getFocusableElement().id });
-    });
-    console.log('matched blocks to controls_if:', matchedBlocks);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -50,6 +50,7 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, 'm');
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
+    // Scroll back up, leaving cursor on the draw block out of the viewport.
     await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       workspace.scrollBoundsIntoView(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -9,7 +9,6 @@ import * as chai from 'chai';
 import {Key} from 'webdriverio';
 import {
   sendKeyAndWait,
-  keyUp,
   keyDown,
   keyRight,
   PAUSE_TIME,
@@ -50,7 +49,7 @@ suite('Scrolling into view', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -18,7 +18,6 @@ import {
   testSetup,
   checkForFailures,
   idle,
-  setPauseTime,
 } from './test_setup.js';
 
 suite('Scrolling into view', function () {

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -117,6 +117,7 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(5000);
+    await this.browser.saveScreenshot(`failures/extra_snapshot_for_verification.png`);
     const blockBounds = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -21,22 +21,17 @@ suite('Scrolling into view', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
   if (PAUSE_TIME) this.timeout(0);
 
-  // Resize browser to provide predictable small window size for scrolling.
+  // Resize browser to provide predictable small viewport size for scrolling.
   //
   // N.B. that this is called only one per suite, not once per test.
   suiteSetup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    // this.windowSize = await this.browser.getWindowSize();
-    await this.browser.setViewport({width: 800, height: 600, devicePixelRatio: 1});
+    // Note that a viewport is used here over adjusting window size to ensure
+    // consistency across platforms and environments.
+    await this.browser.setViewport({
+      width: 800, height: 600, devicePixelRatio: 1
+    });
     await this.browser.pause(PAUSE_TIME);
-  });
-
-  // Restore original browser window size.
-  suiteTeardown(async function () {
-    // await this.browser.setWindowSize(
-    //   this.windowSize.width,
-    //   this.windowSize.height,
-    // );
   });
 
   // Clear the workspace and load start blocks.
@@ -44,7 +39,7 @@ suite('Scrolling into view', function () {
     await testSetup(testFileLocations.BASE, this.timeout());
   });
 
-  test.only('Insert scrolls new block into view', async function () {
+  test('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 
@@ -72,27 +67,6 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);
-    const blockBounds = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const block = workspace.getBlocksByType(
-        'controls_if',
-      )[0] as Blockly.BlockSvg;
-      const blockBounds = block.getBoundingRectangleWithoutChildren();
-      return blockBounds;
-    });
-    console.log("block bounds:", blockBounds);
-    const viewport = await this.browser.execute(() => {
-      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-      const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
-      const viewport = new Blockly.utils.Rect(
-        rawViewport.top,
-        rawViewport.top + rawViewport.height,
-        rawViewport.left,
-        rawViewport.left + rawViewport.width,
-      );
-      return viewport;
-    });
-    console.log("viewport:", viewport);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -39,7 +39,7 @@ suite('Scrolling into view', function () {
     await testSetup(testFileLocations.BASE, this.timeout());
   });
 
-  test.only('Insert scrolls new block into view', async function () {
+  test('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 
@@ -50,12 +50,6 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, 'm');
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
-    // Scroll back up, leaving cursor on the draw block out of the viewport.
-    // const scrollPosition1 = await this.browser.execute(() => {
-    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-    //   return [workspace.scrollX, workspace.scrollY];
-    // });
-    // console.log("workspace scroll position before scroll:", scrollPosition1);
     await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       workspace.scrollBoundsIntoView(
@@ -64,12 +58,8 @@ suite('Scrolling into view', function () {
         ).getBoundingRectangleWithoutChildren(),
       );
     });
+    // Pause to allow scrolling to stabilize before proceeding.
     await this.browser.pause(PAUSE_TIME);
-    // const scrollPosition2 = await this.browser.execute(() => {
-    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-    //   return [workspace.scrollX, workspace.scrollY];
-    // });
-    // console.log("workspace scroll position after scroll:", scrollPosition2);
 
     // Insert and confirm the test block which should be scrolled into view.
     await sendKeyAndWait(this.browser, 't');
@@ -78,27 +68,6 @@ suite('Scrolling into view', function () {
 
     // Assert new block has been scrolled into the viewport.
     await this.browser.pause(PAUSE_TIME);
-    // const blockBounds = await this.browser.execute(() => {
-    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-    //   const block = workspace.getBlocksByType(
-    //     'controls_if',
-    //   )[0] as Blockly.BlockSvg;
-    //   const blockBounds = block.getBoundingRectangleWithoutChildren();
-    //   return blockBounds;
-    // });
-    // console.log("block bounds:", blockBounds);
-    // const viewport = await this.browser.execute(() => {
-    //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-    //   const rawViewport = workspace.getMetricsManager().getViewMetrics(true);
-    //   const viewport = new Blockly.utils.Rect(
-    //     rawViewport.top,
-    //     rawViewport.top + rawViewport.height,
-    //     rawViewport.left,
-    //     rawViewport.left + rawViewport.width,
-    //   );
-    //   return viewport;
-    // });
-    // console.log("viewport:", viewport);
     const inViewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const block = workspace.getBlocksByType(

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -131,7 +131,49 @@ suite('Scrolling into view', function () {
       const block = workspace.getBlocksByType(
         'controls_if',
       )[0] as Blockly.BlockSvg;
-      return [block.getRelativeToSurfaceXY(), getRelativeXY(block.getSvgRoot())];
+
+      const XY_REGEX = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
+      const XY_STYLE_REGEX =
+        /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
+      const element = block.getSvgRoot();
+      class Coordinate {
+        constructor(public x: number, public y: number){}
+      };
+      const xy = new Coordinate(0, 0);
+      // First, check for x and y attributes.
+      // Checking for the existence of x/y properties is faster than getAttribute.
+      // However, x/y contains an SVGAnimatedLength object, so rely on getAttribute
+      // to get the number.
+      const x = (element as any).x && element.getAttribute('x');
+      const y = (element as any).y && element.getAttribute('y');
+      if (x) {
+        xy.x = parseInt(x);
+      }
+      if (y) {
+        xy.y = parseInt(y);
+      }
+      // Second, check for transform="translate(...)" attribute.
+      const transform = element.getAttribute('transform');
+      const r = transform && transform.match(XY_REGEX);
+      if (r) {
+        xy.x += Number(r[1]);
+        if (r[3]) {
+          xy.y += Number(r[3]);
+        }
+      }
+
+      // Then check for style = transform: translate(...) or translate3d(...)
+      const style = element.getAttribute('style');
+      if (style && style.includes('translate')) {
+        const styleComponents = style.match(XY_STYLE_REGEX);
+        if (styleComponents) {
+          xy.x += Number(styleComponents[1]);
+          if (styleComponents[3]) {
+            xy.y += Number(styleComponents[3]);
+          }
+        }
+      }
+      return [block.getRelativeToSurfaceXY(), xy];
     });
     console.log("block position:", blockPosition, "relative:", blockRelative);
     const [blockParentBounds, blockParentId] = await this.browser.execute(() => {
@@ -173,99 +215,3 @@ suite('Scrolling into view', function () {
     chai.assert.isTrue(inViewport);
   });
 });
-
-const XY_REGEX = /translate\(\s*([-+\d.e]+)([ ,]\s*([-+\d.e]+)\s*)?/;
-const XY_STYLE_REGEX =
-  /transform:\s*translate(?:3d)?\(\s*([-+\d.e]+)\s*px([ ,]\s*([-+\d.e]+)\s*px)?/;
-
-function getRelativeXY(element: Element): Coordinate {
-  const xy = new Coordinate(0, 0);
-  // First, check for x and y attributes.
-  // Checking for the existence of x/y properties is faster than getAttribute.
-  // However, x/y contains an SVGAnimatedLength object, so rely on getAttribute
-  // to get the number.
-  const x = (element as any).x && element.getAttribute('x');
-  const y = (element as any).y && element.getAttribute('y');
-  if (x) {
-    xy.x = parseInt(x);
-  }
-  if (y) {
-    xy.y = parseInt(y);
-  }
-  // Second, check for transform="translate(...)" attribute.
-  const transform = element.getAttribute('transform');
-  const r = transform && transform.match(XY_REGEX);
-  if (r) {
-    xy.x += Number(r[1]);
-    if (r[3]) {
-      xy.y += Number(r[3]);
-    }
-  }
-
-  // Then check for style = transform: translate(...) or translate3d(...)
-  const style = element.getAttribute('style');
-  if (style && style.includes('translate')) {
-    const styleComponents = style.match(XY_STYLE_REGEX);
-    if (styleComponents) {
-      xy.x += Number(styleComponents[1]);
-      if (styleComponents[3]) {
-        xy.y += Number(styleComponents[3]);
-      }
-    }
-  }
-  return xy;
-}
-
-class Coordinate {
-  constructor(
-    public x: number,
-    public y: number,
-  ) {}
-
-  clone(): Coordinate {
-    return new Coordinate(this.x, this.y);
-  }
-
-  scale(s: number): Coordinate {
-    this.x *= s;
-    this.y *= s;
-    return this;
-  }
-
-  translate(tx: number, ty: number): Coordinate {
-    this.x += tx;
-    this.y += ty;
-    return this;
-  }
-
-  static equals(a?: Coordinate | null, b?: Coordinate | null): boolean {
-    if (a === b) {
-      return true;
-    }
-    if (!a || !b) {
-      return false;
-    }
-    return a.x === b.x && a.y === b.y;
-  }
-
-  static distance(a: Coordinate, b: Coordinate): number {
-    const dx = a.x - b.x;
-    const dy = a.y - b.y;
-    return Math.sqrt(dx * dx + dy * dy);
-  }
-
-  static magnitude(a: Coordinate): number {
-    return Math.sqrt(a.x * a.x + a.y * a.y);
-  }
-
-  static difference(
-    a: Coordinate | SVGPoint,
-    b: Coordinate | SVGPoint,
-  ): Coordinate {
-    return new Coordinate(a.x - b.x, a.y - b.y);
-  }
-
-  static sum(a: Coordinate | SVGPoint, b: Coordinate | SVGPoint): Coordinate {
-    return new Coordinate(a.x + b.x, a.y + b.y);
-  }
-}

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -50,6 +50,12 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, 'm');
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
+    const movedBlockBounds = await this.browser.execute(() => {
+      const block = Blockly.getFocusManager().getFocusedNode() as Blockly.BlockSvg;
+      const blockBounds = block.getBoundingRectangleWithoutChildren();
+      return blockBounds;
+    });
+    console.log("just moved block bounds:", movedBlockBounds);
     // Scroll back up, leaving cursor on the draw block out of the viewport.
     const scrollPosition1 = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -61,7 +61,7 @@ suite('Scrolling into view', function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 
-    setPauseTime(0);
+    // setPauseTime(0);
     await tabNavigateToWorkspace(this.browser);
 
     // Separate the two top-level blocks by moving p5_draw_1 further down.
@@ -69,7 +69,7 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, 'm');
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
-    setPauseTime(1000);
+    // setPauseTime(1000);
     const movedBlockBounds = await this.browser.execute(() => {
       const block = Blockly.getFocusManager().getFocusedNode() as Blockly.BlockSvg;
       const blockBounds = block.getBoundingRectangleWithoutChildren();

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -18,6 +18,7 @@ import {
   testSetup,
   checkForFailures,
   idle,
+  setPauseTime,
 } from './test_setup.js';
 
 suite('Scrolling into view', function () {
@@ -56,10 +57,11 @@ suite('Scrolling into view', function () {
     await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
-  test('Insert scrolls new block into view', async function () {
+  test.only('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 
+    setPauseTime(0);
     await tabNavigateToWorkspace(this.browser);
 
     // Separate the two top-level blocks by moving p5_draw_1 further down.
@@ -67,6 +69,7 @@ suite('Scrolling into view', function () {
     await sendKeyAndWait(this.browser, 'm');
     await sendKeyAndWait(this.browser, [Key.Alt, Key.ArrowDown], 25);
     await sendKeyAndWait(this.browser, Key.Enter);
+    setPauseTime(1000);
     const movedBlockBounds = await this.browser.execute(() => {
       const block = Blockly.getFocusManager().getFocusedNode() as Blockly.BlockSvg;
       const blockBounds = block.getBoundingRectangleWithoutChildren();

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -64,6 +64,7 @@ suite('Scrolling into view', function () {
         ).getBoundingRectangleWithoutChildren(),
       );
     });
+    await this.browser.pause(PAUSE_TIME);
     // const scrollPosition2 = await this.browser.execute(() => {
     //   const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
     //   return [workspace.scrollX, workspace.scrollY];

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -39,7 +39,7 @@ suite('Scrolling into view', function () {
     await testSetup(testFileLocations.BASE, this.timeout());
   });
 
-  test.only('Insert scrolls new block into view', async function () {
+  test('Insert scrolls new block into view', async function () {
     // Increase timeout to 10s for this longer test.
     this.timeout(PAUSE_TIME ? 0 : 10000);
 

--- a/test/webdriverio/test/scroll_test.ts
+++ b/test/webdriverio/test/scroll_test.ts
@@ -107,6 +107,15 @@ suite('Scrolling into view', function () {
       return blockBounds;
     });
     console.log("block bounds:", blockBounds);
+    const [blockParentBounds, blockParentId] = await this.browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      const block = workspace.getBlocksByType(
+        'controls_if',
+      )[0] as Blockly.BlockSvg;
+      const blockBounds = block.getParent()?.getBoundingRectangleWithoutChildren();
+      return [blockBounds, block.getParent()?.getFocusableElement()?.id];
+    });
+    console.log("block's parent bounds:", blockParentBounds, "id:", blockParentId);
     const viewport = await this.browser.execute(() => {
       const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
       const rawViewport = workspace.getMetricsManager().getViewMetrics(true);

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -14,18 +14,22 @@ import {
   testSetup,
   sendKeyAndWait,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 
 suite('Stack navigation', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.COMMENTS, this.timeout());
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Next', async function () {

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -14,13 +14,14 @@ import {
   testSetup,
   sendKeyAndWait,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 
 suite('Stack navigation', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.COMMENTS, this.timeout());
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -8,7 +8,6 @@ import * as chai from 'chai';
 import {
   getCurrentFocusedBlockId,
   getCurrentFocusNodeId,
-  PAUSE_TIME,
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
@@ -27,7 +26,7 @@ suite('Stack navigation', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -13,6 +13,7 @@ import {
   testFileLocations,
   testSetup,
   sendKeyAndWait,
+  checkForFailures,
 } from './test_setup.js';
 
 suite('Stack navigation', function () {
@@ -20,6 +21,10 @@ suite('Stack navigation', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.COMMENTS, this.timeout());
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Next', async function () {

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -15,7 +15,7 @@ import {
   testFileLocations,
   testSetup,
   checkForFailures,
-  idle,
+  pause,
 } from './test_setup.js';
 import * as chai from 'chai';
 
@@ -26,11 +26,15 @@ suite('Styling test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   async function strokeColorEquals(

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -32,7 +32,7 @@ suite('Styling test', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -15,6 +15,7 @@ import {
   testFileLocations,
   testSetup,
   checkForFailures,
+  idle,
 } from './test_setup.js';
 import * as chai from 'chai';
 
@@ -25,7 +26,7 @@ suite('Styling test', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {

--- a/test/webdriverio/test/styling_test.ts
+++ b/test/webdriverio/test/styling_test.ts
@@ -14,6 +14,7 @@ import {
   tabNavigateToWorkspace,
   testFileLocations,
   testSetup,
+  checkForFailures,
 } from './test_setup.js';
 import * as chai from 'chai';
 
@@ -25,6 +26,10 @@ suite('Styling test', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   async function strokeColorEquals(

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -44,6 +44,8 @@ let driver: webdriverio.Browser | null = null;
  */
 export const PAUSE_TIME = 0;
 
+var synchronizeCoreBlocklyRendering: boolean = true;
+
 /**
  * Start up WebdriverIO and load the test page. This should only be
  * done once, to avoid constantly popping browser windows open and
@@ -119,6 +121,9 @@ export async function testSetup(
   playgroundUrl: string,
   wdioWaitTimeoutMs: number,
 ): Promise<webdriverio.Browser> {
+  // Reset back to default state between tests.
+  synchronizeCoreBlocklyRendering = true;
+
   if (!driver) {
     driver = await driverSetup(wdioWaitTimeoutMs);
   }
@@ -202,24 +207,61 @@ export async function getSelectedBlockId(browser: WebdriverIO.Browser) {
   });
 }
 
-export async function idle(browser: WebdriverIO.Browser) {
-  // First, attempt to synchronize on rendering to ensure that Blockly is fully
-  // rendered before pausing for browser execution. This works around potential
-  // bugs when running in headless mode that can cause requestAnimationFrame to
-  // not call back (and cause state inconsistencies in block positions and sizes
-  // per #770).
-  await browser.execute(() => {
-    const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
-    // Queue re-rendering all blocks.
-    workspace.render();
-    // Flush the rendering queue (this is a slight hack to leverage
-    // BlockSvg.render() directly blocking on rendering finishing).
-    const blocks = workspace.getTopBlocks();
-    if (blocks.length > 0) {
-      blocks[0].render();
-    }
-  });
+/**
+ * Idles the browser for PAUSE_TIME, also possibly synchronizing rendering in
+ * core Blockly.
+ *
+ * This generally should always be preferred over calling browser.pause()
+ * directly.
+ *
+ * See setSynchronizeCoreBlocklyRendering() for additional details on
+ * configuring how this function behaves.
+ *
+ * @param browser The active WebdriverIO Browser object.
+ */
+export async function idle(browser: WebdriverIO.Browser, synchronizeRendering: boolean = true) {
+  if (synchronizeCoreBlocklyRendering) {
+    // First, attempt to synchronize on rendering to ensure that Blockly is
+    // fully rendered before pausing for browser execution. This works around
+    // potential bugs when running in headless mode that can cause
+    // requestAnimationFrame to not call back (and cause state inconsistencies
+    // in block positions and sizes per #770).
+    await browser.execute(() => {
+      const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+      // Queue re-rendering all blocks.
+      workspace.render();
+      // Flush the rendering queue (this is a slight hack to leverage
+      // BlockSvg.render() directly blocking on rendering finishing).
+      const blocks = workspace.getTopBlocks();
+      if (blocks.length > 0) {
+        blocks[0].render();
+      }
+    });
+  }
   await browser.pause(PAUSE_TIME);
+}
+
+/**
+ * Configures whether to synchronize core Blockly's rendering system when trying
+ * to idle tests to wait for operations to complete.
+ *
+ * This is enabled by default and changes the behavior of idle() which is used
+ * both directly in tests and indirectly via the many test helpers in this file.
+ *
+ * Synchronization is useful because it ensures Blockly is fully rendered and
+ * stable before proceeding with the test (which can sometimes be desynchronized
+ * if the headless test environment drops a request for animation rendering
+ * frame which has been observed in CI environments).
+ *
+ * Synchronization must be disabled in certain tests, particularly those that
+ * can trigger alert dialogs since, when open, these will always cause any
+ * browser.execute() calls to fail the test (and rendering synchronization
+ * relies on this WebdriverIO mechanism).
+ *
+ * @param enableSynchronization
+ */
+export async function setSynchronizeCoreBlocklyRendering(enableSynchronization: boolean) {
+  synchronizeCoreBlocklyRendering = enableSynchronization;
 }
 
 /**

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export const PAUSE_TIME = 0;
+export const PAUSE_TIME = 200;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -79,7 +79,7 @@ export async function driverSetup(
   // Run in headless mode on Github Actions.
   if (process.env.CI) {
     options.capabilities['goog:chromeOptions'].args.push(
-      '--headless=new',
+      '--headless',
       '--no-sandbox',
       '--disable-dev-shm-usage',
     );
@@ -204,6 +204,13 @@ export async function getSelectedBlockId(browser: WebdriverIO.Browser) {
   });
 }
 
+export async function idle(browser: WebdriverIO.Browser) {
+  await browser.execute(() => {
+    (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg).render();
+  });
+  await browser.pause(PAUSE_TIME);
+}
+
 /**
  * Clicks in the workspace to focus it.
  *
@@ -214,7 +221,7 @@ export async function focusWorkspace(browser: WebdriverIO.Browser) {
     '#blocklyDiv > div > svg.blocklySvg > g',
   );
   await workspaceElement.click({x: 100});
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 }
 
 /**
@@ -303,7 +310,7 @@ export async function focusOnBlock(
     if (!block) throw new Error(`No block found with ID: ${blockId}.`);
     Blockly.getFocusManager().focusNode(block);
   }, blockId);
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 }
 
 /**
@@ -326,7 +333,7 @@ export async function focusOnWorkspaceComment(
     }
     Blockly.getFocusManager().focusNode(comment);
   }, commentId);
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 }
 
 /**
@@ -358,7 +365,7 @@ export async function focusOnBlockField(
     blockId,
     fieldName,
   );
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 }
 
 /**
@@ -491,7 +498,7 @@ export async function tabNavigateToWorkspace(
   // there's no straightforward way to do that; see
   // https://stackoverflow.com/q/51518855/4969945
   await browser.execute(() => document.getElementById('focusableDiv')?.focus());
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
   // Navigate to workspace.
   if (hasToolbox) await tabNavigateForward(browser);
   if (hasFlyout) await tabNavigateForward(browser);
@@ -591,7 +598,7 @@ export async function sendKeyAndWait(
   } else {
     for (let i = 0; i < times; i++) {
       await browser.keys(keys);
-      await browser.pause(PAUSE_TIME);
+      await idle(browser);
     }
   }
 }
@@ -737,13 +744,13 @@ export async function clickBlock(
     blockId,
     findableId,
   );
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 
   // In the test context, get the WebdriverIO Element that we've identified.
   const elem = await browser.$(`#${findableId}`);
 
   await elem.click(clickOptions);
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 
   // In the browser context, remove the ID.
   await browser.execute((elemId) => {
@@ -763,5 +770,5 @@ export async function rightClickOnFlyoutBlockType(
 ) {
   const elem = await browser.$(`.blocklyFlyout .${blockType}`);
   await elem.click({button: 'right'});
-  await browser.pause(PAUSE_TIME);
+  await idle(browser);
 }

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,9 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export const PAUSE_TIME = 0;
+export var PAUSE_TIME = 1000;
+
+export function setPauseTime(time: number) { PAUSE_TIME = time; }
 
 /**
  * Start up WebdriverIO and load the test page. This should only be
@@ -595,6 +597,7 @@ export async function sendKeyAndWait(
     // Send all keys in one call if no pauses needed.
     keys = Array(times).fill(keys).flat();
     await browser.keys(keys);
+    await idle(browser);
   } else {
     for (let i = 0; i < times; i++) {
       await browser.keys(keys);

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export const PAUSE_TIME = 10;
+export const PAUSE_TIME = 0;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export var PAUSE_TIME = 1000;
+export var PAUSE_TIME = 0;
 
 export function setPauseTime(time: number) { PAUSE_TIME = time; }
 
@@ -208,7 +208,15 @@ export async function getSelectedBlockId(browser: WebdriverIO.Browser) {
 
 export async function idle(browser: WebdriverIO.Browser) {
   await browser.execute(() => {
-    (Blockly.getMainWorkspace() as Blockly.WorkspaceSvg).render();
+    const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
+    // Queue re-rendering all blocks.
+    workspace.render();
+    // Flush the rendering queue (this is a slight hack to leverage
+    // BlockSvg.render() directly blocking on rendering finishing).
+    const blocks = workspace.getTopBlocks();
+    if (blocks.length > 0) {
+      blocks[0].render();
+    }
   });
   await browser.pause(PAUSE_TIME);
 }

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export const PAUSE_TIME = 200;
+export const PAUSE_TIME = 0;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,9 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export var PAUSE_TIME = 0;
-
-export function setPauseTime(time: number) { PAUSE_TIME = time; }
+export const PAUSE_TIME = 0;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be
@@ -65,10 +63,8 @@ export async function driverSetup(
       'unhandledPromptBehavior': 'ignore',
       // eslint-disable-next-line @typescript-eslint/naming-convention
       'goog:chromeOptions': {
-        args: ['--allow-file-access-from-files', '--user_agent=Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.44 (KHTML, like Gecko) JavaFX/8.0 Safari/537.44'],
+        args: ['--allow-file-access-from-files'],
       },
-      // Allows certain BiDi features to work correctly.
-      // 'webSocketUrl': true
       // We aren't (yet) using any BiDi features, and BiDi is sensitive to
       // mismatches between Chrome version and Chromedriver version.
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -207,6 +203,11 @@ export async function getSelectedBlockId(browser: WebdriverIO.Browser) {
 }
 
 export async function idle(browser: WebdriverIO.Browser) {
+  // First, attempt to synchronize on rendering to ensure that Blockly is fully
+  // rendered before pausing for browser execution. This works around potential
+  // bugs when running in headless mode that can cause requestAnimationFrame to
+  // not call back (and cause state inconsistencies in block positions and sizes
+  // per #770).
   await browser.execute(() => {
     const workspace = Blockly.getMainWorkspace() as Blockly.WorkspaceSvg;
     // Queue re-rendering all blocks.

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -42,7 +42,7 @@ let driver: webdriverio.Browser | null = null;
  * the browser.wait* functions if you need your test to wait for
  * something to happen after sending input.
  */
-export const PAUSE_TIME = 0;
+export const PAUSE_TIME = 10;
 
 /**
  * Start up WebdriverIO and load the test page. This should only be

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -63,7 +63,7 @@ export async function driverSetup(
       'unhandledPromptBehavior': 'ignore',
       // eslint-disable-next-line @typescript-eslint/naming-convention
       'goog:chromeOptions': {
-        args: ['--allow-file-access-from-files'],
+        args: ['--allow-file-access-from-files', '--user_agent=Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.44 (KHTML, like Gecko) JavaFX/8.0 Safari/537.44'],
       },
       // Allows certain BiDi features to work correctly.
       // 'webSocketUrl': true

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -128,6 +128,16 @@ export async function testSetup(
   return driver;
 }
 
+export async function checkForFailures(
+  browser: WebdriverIO.Browser,
+  testTitle: string,
+  testState: string | undefined
+) {
+  if (testState === 'failed') {
+    await browser.saveScreenshot(`failures/${testTitle}.png`);
+  }
+}
+
 /**
  * Replaces OS-specific path with POSIX style path.
  *

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -146,15 +146,18 @@ export async function testSetup(
  * to the current test's title.
  *
  * @param browser The active WebdriverIO Browser object.
- * @param testTitle The current running test's title.
+ * @param testTitle The current running test's title, if known.
  * @param testState The current running test's completion state, if known.
  */
 export async function checkForFailures(
   browser: WebdriverIO.Browser,
-  testTitle: string,
+  testTitle: string | undefined,
   testState: string | undefined,
 ) {
   if (testState === 'failed') {
+    if (!testTitle) {
+      throw new Error('Test failed and finished with no test title.');
+    }
     await browser.saveScreenshot(`failures/${testTitle}.png`);
   }
 }

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -65,10 +65,8 @@ export async function driverSetup(
       'goog:chromeOptions': {
         args: ['--allow-file-access-from-files'],
       },
-      // We aren't (yet) using any BiDi features, and BiDi is sensitive to
-      // mismatches between Chrome version and Chromedriver version.
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      'wdio:enforceWebDriverClassic': true,
+      // Allows certain BiDi features to work correctly.
+      'webSocketUrl': true
     },
     waitforTimeout: wdioWaitTimeoutMs,
     logLevel: 'warn' as const,

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -66,7 +66,11 @@ export async function driverSetup(
         args: ['--allow-file-access-from-files'],
       },
       // Allows certain BiDi features to work correctly.
-      'webSocketUrl': true
+      // 'webSocketUrl': true
+      // We aren't (yet) using any BiDi features, and BiDi is sensitive to
+      // mismatches between Chrome version and Chromedriver version.
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'wdio:enforceWebDriverClassic': true,
     },
     waitforTimeout: wdioWaitTimeoutMs,
     logLevel: 'warn' as const,

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -79,7 +79,7 @@ export async function driverSetup(
   // Run in headless mode on Github Actions.
   if (process.env.CI) {
     options.capabilities['goog:chromeOptions'].args.push(
-      '--headless',
+      '--headless=new',
       '--no-sandbox',
       '--disable-dev-shm-usage',
     );

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -126,6 +126,11 @@ export async function testSetup(
 
   if (!driver) {
     driver = await driverSetup(wdioWaitTimeoutMs);
+  } else if (process.env.CI) {
+    // If running in CI force a session reload to ensure no browser state can
+    // leak across test suites (since this can sometimes cause complex combined
+    // failures in CI).
+    await driver.reloadSession();
   }
   await driver.url(playgroundUrl);
   // Wait for the workspace to exist and be rendered.

--- a/test/webdriverio/test/test_setup.ts
+++ b/test/webdriverio/test/test_setup.ts
@@ -128,7 +128,7 @@ export async function testSetup(
     driver = await driverSetup(wdioWaitTimeoutMs);
   } else if (process.env.CI) {
     // If running in CI force a session reload to ensure no browser state can
-    // leak across test suites (since this can sometimes cause complex combined
+    // leak across tests (since this can sometimes cause complex combined
     // failures in CI).
     await driver.reloadSession();
   }

--- a/test/webdriverio/test/toast_test.ts
+++ b/test/webdriverio/test/toast_test.ts
@@ -6,7 +6,13 @@
 
 import * as chai from 'chai';
 import * as Blockly from 'blockly/core';
-import {PAUSE_TIME, testFileLocations, testSetup, checkForFailures, idle} from './test_setup.js';
+import {
+  PAUSE_TIME,
+  testFileLocations,
+  testSetup,
+  checkForFailures,
+  pause,
+} from './test_setup.js';
 
 suite('HTML toasts', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
@@ -15,11 +21,15 @@ suite('HTML toasts', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await idle(this.browser);
+    await pause(this.browser);
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Can be displayed', async function () {

--- a/test/webdriverio/test/toast_test.ts
+++ b/test/webdriverio/test/toast_test.ts
@@ -27,7 +27,7 @@ suite('HTML toasts', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/toast_test.ts
+++ b/test/webdriverio/test/toast_test.ts
@@ -6,7 +6,7 @@
 
 import * as chai from 'chai';
 import * as Blockly from 'blockly/core';
-import {PAUSE_TIME, testFileLocations, testSetup} from './test_setup.js';
+import {PAUSE_TIME, testFileLocations, testSetup, checkForFailures} from './test_setup.js';
 
 suite('HTML toasts', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
@@ -16,6 +16,10 @@ suite('HTML toasts', function () {
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
     await this.browser.pause(PAUSE_TIME);
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Can be displayed', async function () {

--- a/test/webdriverio/test/toast_test.ts
+++ b/test/webdriverio/test/toast_test.ts
@@ -6,7 +6,7 @@
 
 import * as chai from 'chai';
 import * as Blockly from 'blockly/core';
-import {PAUSE_TIME, testFileLocations, testSetup, checkForFailures} from './test_setup.js';
+import {PAUSE_TIME, testFileLocations, testSetup, checkForFailures, idle} from './test_setup.js';
 
 suite('HTML toasts', function () {
   // Disable timeouts when non-zero PAUSE_TIME is used to watch tests run.
@@ -15,7 +15,7 @@ suite('HTML toasts', function () {
   // Clear the workspace and load start blocks.
   setup(async function () {
     this.browser = await testSetup(testFileLocations.BASE, this.timeout());
-    await this.browser.pause(PAUSE_TIME);
+    await idle(this.browser);
   });
 
   teardown(async function() {

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -20,6 +20,7 @@ import {
   keyUp,
   contextMenuItems,
   PAUSE_TIME,
+  checkForFailures,
 } from './test_setup.js';
 import {Key} from 'webdriverio';
 
@@ -67,6 +68,10 @@ suite('Workspace comment navigation', function () {
         return [bounds.left, bounds.top];
       }, commentId);
     };
+  });
+
+  teardown(async function() {
+    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
   });
 
   test('Navigate forward from block to workspace comment', async function () {

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -70,8 +70,12 @@ suite('Workspace comment navigation', function () {
     };
   });
 
-  teardown(async function() {
-    await checkForFailures(this.browser, this.currentTest!.title, this.currentTest?.state);
+  teardown(async function () {
+    await checkForFailures(
+      this.browser,
+      this.currentTest!.title,
+      this.currentTest?.state,
+    );
   });
 
   test('Navigate forward from block to workspace comment', async function () {

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -73,7 +73,7 @@ suite('Workspace comment navigation', function () {
   teardown(async function () {
     await checkForFailures(
       this.browser,
-      this.currentTest!.title,
+      this.currentTest?.title,
       this.currentTest?.state,
     );
   });

--- a/test/webdriverio/test/workspace_comment_test.ts
+++ b/test/webdriverio/test/workspace_comment_test.ts
@@ -151,7 +151,7 @@ suite('Workspace comment navigation', function () {
       return Blockly.getMainWorkspace()
         .getCommentById(commentId)
         ?.isCollapsed();
-    }, this.commentId1);
+    }, this.commentId1 as string);
     chai.assert.isTrue(collapsed);
   });
 
@@ -172,7 +172,7 @@ suite('Workspace comment navigation', function () {
 
     const commentText = await this.browser.execute((commentId) => {
       return Blockly.getMainWorkspace().getCommentById(commentId)?.getText();
-    }, this.commentId1);
+    }, this.commentId1 as string);
     chai.assert.equal(commentText, 'Comment oneHello world');
   });
 


### PR DESCRIPTION
Fixes #746

This PR does a bunch of things, but most importantly it fixes repeatedly failing OS X tests that ran in CI. These fell into two categories:
- A single scrolling test that would always fail due to a dropped rendering frame in headless Chrome at an inopportune point in the test.
- Two `alert` tests that would reliably cause a _different_ test to timeout.

These two fixes required completely different solutions and underwent different investigations. A long discussion of the investigation can be found in the conversation thread in this PR.

### Fixing `alert` dialog problems

These failures were a bit odd. Two flyout tests verify callback logic which is set up in the test to open an alert dialog. These tests pass without an issue. However, when either one of these tests is run exactly before move start tests (both of them). The first move start test will pass, the second will reliably time out in CI on OS X. Sometimes WebdriverIO will include errors about focus issues, but this didn't always happen.

The best guess here is that there's an actual issue in Chrome and/or WebdriverIO specifically with alert dialogs that is putting the framework or browser into a bad state. Blockly shares no state across its tests due to page reloads and no cookies or local storage being leveraged, but forcing a session reload between tests (i.e. a full browser reopen) fixes the issue which seems to confirm that it's an issue in the framework environment and not Blockly. This seems like a reasonable fix.

Note that this is sort of discouraged due to session reloading increasing test runtime, but the CI completions do not seem much slower than before even with the extra reloads. Locally it takes 2-3x longer to run when using headless mode. When using non-headless mode it encounters actual failures, but fortunately this needs to be forced since the setup currently is such that session reloading will only ever happen with headless runs. It also seems likely that forcing session reloads like this will actually improve other behavioral inconsistencies or flakes in the tests, as well.

Session reloading has only been enabled for CI runs of tests since it shouldn't be needed locally, at least per observation (though it can be demonstrated locally using the command: `CI=true npm run test:ci`).

### Fixing rendering synchronization issues

The rendering issue came down to the fact that Blockly can get into a temporarily broken state if its rendering queue is not run. Since Blockly relies on `requestAnimationFrame` for this to occur, dropped frames (which are legitimate according to the spec and something we can observe specifically in Mac CI with headless Chrome) will lead to block positioning not updating when the test expects, leading to a failing test. This can be easily reproduced even on Linux locally by linking against a version of Blockly that forces immediate rendering (e.g. pretending JavaFX is enabled).

The fix was to force the tests to try and trigger a re-render of the workspace at select moments. During investigation it was easiest just to do this everywhere there's a moment to pause execution since that's effectively a time when the test actually wants to wait for things to 'settle', so this is what's actually changed in the PR. All previous moments of pausing execution now route through a specific utility function that also will try to force rendering of Blockly, bypassing any dropped frames that the browser might introduce and ensuring tests are a lot more stable. It seems possible (though it hasn't been proven) that other tests may have also been flaky due to this behavior.

It's important to note that this _might_ be a bug in core Blockly, but the reality is it seems nearly impossible to ever actually occur. Even if a browser dropped or delayed a rendering frame, eventual consistency should kick in since Blockly does deterministically render itself and thus will self-correct on the next render (which is fundamentally why the solution above works as well as it does).

Note also that this fix had a compatibility issue with the dialog fix above and required a special setting to disable synchronization since it's not valid in WebdriverIO to execute browser-side code while a dialog is open (and attempting to detect this results in a significant slowdown in CI runtime and a large increase in console warnings).

### Other test infrastructure improvements

As part of the investigation it was useful to try and see what the tests were doing when they failed. WebdriverIO supports this with a built-in `saveScreenshot` function. All test suites have been updated in this PR to automatically check for failures when they finish each test and, if there's a failure, the current screen state will be snapshotted and uploaded to a zip file (specific to the OS) in GitHub Actions.

This actually did help with determining the root rendering issue because the screenshot showed a correct block layout even though debug logs showed incorrect positions. At first this hinted toward inconsistencies between the data model and actual rendering, but continued investigation eventually revealed the rendering frame being dropped (and the screenshot function was likely forcing rendering and 'correcting' the broken state).

Failures will also be screenshotted for local tests and saved in `test/webdriverio/test/failures/` with a filename corresponding to the test's name. These are automatically ignored from being added to Git via `.gitignore`.

Finally, a couple other miscellaneous changes:
- One additional pause was added to the scroll test. This probably isn't needed, but more pauses generally help with stability.
- Ditto for `sendKeyAndWait` though this was more of a contract correction: if `PAUSE_TIME` was zero then it wasn't actually waiting anymore which seemed incorrect. That's been fixed.
- There are some new string casts that seem necessary after some NPM upgrades, and they're generally innocuous.

And one final note: this PR mainly ensures all tests generally pass, not that there are no flakes. From observation tests may still flake on occasion, but they can be restarted and generally expected to pass. The OS X tests ran 14 times in a row without a failure before running into the 6 hour GitHub Actions runtime limit (it seems they slowed down each subsequent run, perhaps due to some sort of memory or resource leak). It may be possible to add a "try 3 times" approach to the WebdriverIO tests in CI in the future to significantly reduce flakes and increase the trustworthiness of failures to be actual problems, but this PR does not address that.