### PR TITLE
fix: Support more complex 'simple reporter' blocks (experimental)

### DIFF
--- a/src/actions/enter.ts
+++ b/src/actions/enter.ts
@@ -350,7 +350,7 @@ export class EnterAction {
    * @returns True if we showed the editor, false otherwise.
    */
   private tryShowFullBlockFieldEditor(block: Block): boolean {
-    if (block.isSimpleReporter()) {
+    if (block.isSimpleReporter(true, true)) {
       for (const input of block.inputList) {
         for (const field of input.fieldRow) {
           if (field.isClickable() && field.isFullBlockField()) {


### PR DESCRIPTION
Fixes https://github.com/RaspberryPiFoundation/blockly/issues/9456

This updates the 'enter' shortcut to work correctly for blocks that can have more than field but still be considered 'single input' (due to only having one mutable field). The base support for this change was done in the experimental branch in core Blockly via #9484.