### PR TITLE
chore: Update workflows to reference `main` instead of `develop`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build_tip_of_tree_v12:
-    name: Build test (against tip-of-tree core develop)
+    name: Build test (against tip-of-tree core main)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout experimentation plugin
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'google/blockly'
-          ref: 'develop'
+          ref: 'main'
           path: core-blockly
 
       - name: Use Node.js 20.x
@@ -42,7 +42,7 @@ jobs:
           npm install
           cd ..
 
-      - name: Link latest Blockly develop
+      - name: Link latest Blockly main
         run: |
           cd core-blockly
           npm run package

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: blockly
           repository: google/blockly
-          ref: develop
+          ref: main
 
       - name: Checkout add-screen-reader-support-experimental core Blockly
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   webdriverio_tests_tip_of_tree_v12:
-    name: WebdriverIO tests (against tip-of-tree core develop)
+    name: WebdriverIO tests (against tip-of-tree core main)
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}
 
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'google/blockly'
-          ref: 'develop'
+          ref: 'main'
           path: core-blockly
 
       - name: Use Node.js 20.x
@@ -50,7 +50,7 @@ jobs:
           npm install
           cd ..
 
-      - name: Link latest Blockly develop
+      - name: Link latest Blockly main
         run: |
           cd core-blockly
           npm run package


### PR DESCRIPTION
This PR fixes part of [#9516 ](https://github.com/RaspberryPiFoundation/blockly/issues/9516) by updating several GitHub workflows to reference the `main` branch in core Blockly rather than the now-removed `develop` branch.