### PR TITLE
fix: Don't loop around when navigating

### DIFF
--- a/src/actions/arrow_navigation.ts
+++ b/src/actions/arrow_navigation.ts
@@ -66,7 +66,10 @@ export class ArrowNavigation {
             if (
               !this.navigation.defaultWorkspaceCursorPositionIfNeeded(workspace)
             ) {
-              workspace.getCursor().in();
+              const newNode = workspace.getCursor().in();
+              if (!newNode) {
+                workspace.getAudioManager().beep(260);
+              }
             }
             isHandled = true;
           }
@@ -99,7 +102,10 @@ export class ArrowNavigation {
             if (
               !this.navigation.defaultWorkspaceCursorPositionIfNeeded(workspace)
             ) {
-              workspace.getCursor().out();
+              const newNode = workspace.getCursor().out();
+              if (!newNode) {
+                workspace.getAudioManager().beep(260);
+              }
             }
             isHandled = true;
           }
@@ -165,7 +171,10 @@ export class ArrowNavigation {
                     workspace,
                   )
                 ) {
-                  workspace.getCursor().next();
+                  const newNode = workspace.getCursor().next();
+                  if (!newNode) {
+                    workspace.getAudioManager().beep(260);
+                  }
                 }
                 isHandled = true;
               }
@@ -178,7 +187,10 @@ export class ArrowNavigation {
                     workspace.targetWorkspace,
                   )
                 ) {
-                  workspace.getCursor().next();
+                  const newNode = workspace.getCursor().next();
+                  if (!newNode) {
+                    workspace.getAudioManager().beep(260);
+                  }
                 }
                 isHandled = true;
               }
@@ -228,7 +240,10 @@ export class ArrowNavigation {
                     'last',
                   )
                 ) {
-                  workspace.getCursor().prev();
+                  const newNode = workspace.getCursor().prev();
+                  if (!newNode) {
+                    workspace.getAudioManager().beep(260);
+                  }
                 }
                 isHandled = true;
               }
@@ -242,7 +257,10 @@ export class ArrowNavigation {
                     'last',
                   )
                 ) {
-                  workspace.getCursor().prev();
+                  const newNode = workspace.getCursor().prev();
+                  if (!newNode) {
+                    workspace.getAudioManager().beep(260);
+                  }
                 }
                 isHandled = true;
               }

--- a/src/actions/stack_navigation.ts
+++ b/src/actions/stack_navigation.ts
@@ -62,7 +62,10 @@ export class StackNavigationAction {
     }
 
     let nextRoot = navigateStacks(curNodeRoot, delta);
-    if (!nextRoot) return false;
+    if (!nextRoot) {
+      workspace.getAudioManager().beep(260);
+      return false;
+    }
     if (nextRoot instanceof BlockSvg) {
       nextRoot = nextRoot.getRootBlock();
     }

--- a/src/flyout_cursor.ts
+++ b/src/flyout_cursor.ts
@@ -25,6 +25,7 @@ export class FlyoutCursor extends Blockly.LineCursor {
    */
   constructor(private readonly flyout: Blockly.IFlyout) {
     super(flyout.getWorkspace());
+    this.setNavigationLoops(false);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,8 @@ export class KeyboardNavigation {
     workspace.getSvgGroup().appendChild(this.workspaceFocusRing);
     this.resizeWorkspaceRings();
 
+    workspace.getCursor().setNavigationLoops(false);
+
     registerHtmlToast();
   }
 
@@ -307,7 +309,7 @@ export class KeyboardNavigation {
     stroke: var(--blockly-active-node-color);
     stroke-width: var(--blockly-selection-width);
   }
-  
+
   /* The workspace itself is the active node. */
   .blocklyKeyboardNavigation
     .blocklyBubble.blocklyActiveFocus

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,6 @@ export class KeyboardNavigation {
   /** Keyboard navigation controller instance for the workspace. */
   private navigationController: NavigationController;
 
-  /** Cursor for the main workspace. */
-  private cursor: Blockly.LineCursor;
-
   /**
    * Focus ring in the workspace.
    */
@@ -59,8 +56,6 @@ export class KeyboardNavigation {
     this.navigationController.init();
     this.navigationController.addWorkspace(workspace);
     this.navigationController.enable(workspace);
-
-    this.cursor = new Blockly.LineCursor(workspace);
 
     // Add the event listener to enable disabled blocks on drag.
     workspace.addChangeListener(enableBlocksOnDrag);

--- a/test/webdriverio/test/basic_test.ts
+++ b/test/webdriverio/test/basic_test.ts
@@ -49,11 +49,11 @@ suite('Keyboard navigation on Blocks', function () {
     await tabNavigateToWorkspace(this.browser);
     await this.browser.pause(PAUSE_TIME);
 
-    await keyDown(this.browser, 22);
+    await keyDown(this.browser, 13);
 
     chai
       .expect(await getCurrentFocusedBlockId(this.browser))
-      .equal('controls_if_2');
+      .equal('controls_repeat_ext_1');
   });
 
   test('Down from statement block selects next block across stacks', async function () {

--- a/test/webdriverio/test/stack_navigation.ts
+++ b/test/webdriverio/test/stack_navigation.ts
@@ -8,6 +8,7 @@ import * as chai from 'chai';
 import {
   getCurrentFocusedBlockId,
   getCurrentFocusNodeId,
+  focusOnWorkspaceComment,
   PAUSE_TIME,
   tabNavigateToWorkspace,
   testFileLocations,
@@ -39,10 +40,10 @@ suite('Stack navigation', function () {
       await getCurrentFocusNodeId(this.browser),
     );
     await sendKeyAndWait(this.browser, 'n');
-    // Looped around.
+    // Does not loop around.
     chai.assert.equal(
-      'p5_setup_1',
-      await getCurrentFocusedBlockId(this.browser),
+      'workspace_comment_1',
+      await getCurrentFocusNodeId(this.browser),
     );
   });
 
@@ -53,11 +54,14 @@ suite('Stack navigation', function () {
       await getCurrentFocusedBlockId(this.browser),
     );
     await sendKeyAndWait(this.browser, 'b');
-    // Looped to bottom.
+    // Does not loop to bottom.
     chai.assert.equal(
-      'workspace_comment_1',
-      await getCurrentFocusNodeId(this.browser),
+      'p5_setup_1',
+      await getCurrentFocusedBlockId(this.browser),
     );
+
+    await focusOnWorkspaceComment(this.browser, 'workspace_comment_1');
+
     await sendKeyAndWait(this.browser, 'b');
     chai.assert.isTrue(
       (await getCurrentFocusNodeId(this.browser))?.startsWith(


### PR DESCRIPTION
This PR fixes https://github.com/RaspberryPiFoundation/blockly/issues/9496 by disabling looping when using the keyboard to navigate through the workspace, and playing an error tone when the end of the navigable tree is reached.