### PR TITLE
chore(ci): update github workflows for monorepo blockly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,11 +44,11 @@ jobs:
 
       - name: Link latest Blockly main
         run: |
-          cd core-blockly
+          cd core-blockly/packages/blockly
           npm run package
           cd dist
           npm link
-          cd ../../main
+          cd ../../../../main
           npm link blockly
           cd ..
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           cd blockly
           npm ci
+          cd packages/blockly
           npm run package
           cd dist
           npm link
@@ -77,10 +78,11 @@ jobs:
 
       - name: Build add-screen-reader-support-experimental core Blockly
         run: |
-          cd blockly/dist
+          cd blockly/packages/blockly/dist
           npm unlink -g
-          cd ../../blockly-add-screen-reader-support-experimental
+          cd ../../../../blockly-add-screen-reader-support-experimental
           npm ci
+          cd packages/blockly
           npm run package
           cd dist
           npm link

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,11 @@ jobs:
 
       - name: Link latest Blockly main
         run: |
-          cd core-blockly
+          cd core-blockly/packages/blockly
           npm run package
           cd dist
           npm link
-          cd ../../main
+          cd ../../../../main
           npm link blockly
           cd ..
 


### PR DESCRIPTION
Updates CI workflows to cd into correct blockly directories when building against tip-of-tree
