### PR TITLE
fix: Export registerFlyoutCursor as a static method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as Blockly from 'blockly/core';
 import {NavigationController} from './navigation_controller';
 import {enableBlocksOnDrag} from './disabled_blocks';
 import {registerHtmlToast} from './html_toast';
+import {registerFlyoutCursor} from './flyout_cursor';
 
 /** Plugin for keyboard navigation. */
 export class KeyboardNavigation {
@@ -137,6 +138,14 @@ export class KeyboardNavigation {
    */
   toggleShortcutDialog(): void {
     this.navigationController.shortcutDialog.toggle(this.workspace);
+  }
+
+  /**
+   * Registers a specific flyout cursor that allows navigation to
+   * flyout labels and buttons.
+   */
+  static registerFlyoutCursor() {
+    registerFlyoutCursor();
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/RaspberryPiFoundation/blockly-keyboard-experimentation/issues/756

Since v3.0.1 the flyout has been using a `LineCursor` which cannot navigate to flyout labels or buttons. If the button or label is the first item in the flyout, it is focussed by default when moving focus from the toolbox to the flyout, but cannot be navigated to otherwise.

I've added this as a static method following existing convention, but just `export {registerFlyoutCursor} from './flyout_cursor';` would work if it needs to be a separate function.
